### PR TITLE
[codex] Add credential auth and MVP screens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 DATABASE_URL="postgresql://USER:PASSWORD@HOST.neon.tech/neondb?sslmode=require"
 NEXT_PUBLIC_APP_NAME="SkillMatch AI"
 AUTH_SECRET="replace-with-a-long-random-secret"
+AUTH_USERS_JSON='[{"name":"Demo Recruiter","email":"recruiter@skillmatch.demo","role":"recruiter","password":"SkillMatchDemo!23"},{"name":"Demo Admin","email":"admin@skillmatch.demo","role":"system_admin","password":"SkillMatchAdmin!23"},{"name":"Demo Learning","email":"learning@skillmatch.demo","role":"learning_development","password":"SkillMatchLearn!23"}]'
 
 # Optional Cloudflare R2 / S3-compatible resume object storage.
 # Without these values, local development uses an in-memory storage URL.

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,30 +1,29 @@
 import { NextResponse } from "next/server";
 import { setSessionUser } from "@/lib/auth";
-import { demoUsers, type UserRole } from "@/lib/auth-model";
+import { verifyCredentials } from "@/lib/auth-model";
 import { appendAuditEvent } from "@/lib/db";
 
 export async function POST(request: Request) {
   const body = await request.json();
   const email = String(body.email ?? "");
-  const role = String(body.role ?? "employee") as UserRole;
-  const user = demoUsers.find((item) => item.email === email);
+  const password = String(body.password ?? "");
+  const user = await verifyCredentials(email, password);
 
-  if (!user || !email.endsWith("@amazon.com")) {
+  if (!user) {
     await appendAuditEvent({
       actor: email || "anonymous",
       action: "failed_login",
-      details: { reason: "invalid_internal_account" }
+      details: { reason: "invalid_credentials" }
     });
-    return NextResponse.json({ error: "Amazon internal account required." }, { status: 401 });
+    return NextResponse.json({ error: "Invalid email or password." }, { status: 401 });
   }
 
-  const sessionUser = { ...user, role };
-  await setSessionUser(sessionUser);
+  await setSessionUser(user);
   await appendAuditEvent({
-    actor: sessionUser.email,
+    actor: user.email,
     action: "login",
-    details: { role: sessionUser.role }
+    details: { role: user.role }
   });
 
-  return NextResponse.json({ user: sessionUser });
+  return NextResponse.json({ user });
 }

--- a/app/dashboard.tsx
+++ b/app/dashboard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import type { CSSProperties } from "react";
 import {
   Activity,
   AlertTriangle,
@@ -9,16 +10,20 @@ import {
   CheckCircle2,
   ChevronRight,
   FileText,
+  GraduationCap,
   LayoutDashboard,
   LogOut,
+  Search,
   Settings,
   ShieldCheck,
   SlidersHorizontal,
   UploadCloud,
-  Users
+  Users,
+  type LucideIcon
 } from "lucide-react";
 import { roles } from "@/lib/seed-data";
 import type { SessionUser } from "@/lib/auth-model";
+import type { AnalysisRecord, AuditEvent } from "@/lib/db";
 import type { CandidateAnalysis } from "@/lib/skillmatch";
 
 type UploadResponse = {
@@ -26,14 +31,29 @@ type UploadResponse = {
   failures: Array<{ fileName: string; error: string }>;
 };
 
+type View = "dashboard" | "analyses" | "learning" | "workforce" | "audit" | "settings";
+
+const navItems: Array<{ id: View; label: string; icon: LucideIcon }> = [
+  { id: "dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { id: "analyses", label: "Analyses", icon: BarChart3 },
+  { id: "learning", label: "Learning", icon: BookOpen },
+  { id: "workforce", label: "Workforce", icon: Users },
+  { id: "audit", label: "Audit Log", icon: ShieldCheck },
+  { id: "settings", label: "Settings", icon: Settings }
+];
+
 export default function Dashboard({ user }: { user: SessionUser }) {
+  const [view, setView] = useState<View>("dashboard");
   const [roleId, setRoleId] = useState("sde-ii");
   const [files, setFiles] = useState<File[]>([]);
   const [candidates, setCandidates] = useState<CandidateAnalysis[]>([]);
+  const [analyses, setAnalyses] = useState<AnalysisRecord[]>([]);
+  const [auditEvents, setAuditEvents] = useState<AuditEvent[]>([]);
   const [failures, setFailures] = useState<UploadResponse["failures"]>([]);
   const [selectedCandidateId, setSelectedCandidateId] = useState<string>("");
   const [isUploading, setIsUploading] = useState(false);
   const [notice, setNotice] = useState("");
+  const [query, setQuery] = useState("");
 
   const selectedRole = roles.find((role) => role.id === roleId) ?? roles[0];
   const selectedCandidate = candidates.find((candidate) => candidate.id === selectedCandidateId) ?? candidates[0];
@@ -49,16 +69,48 @@ export default function Dashboard({ user }: { user: SessionUser }) {
     });
     return Array.from(counts.entries())
       .sort((a, b) => b[1] - a[1])
-      .slice(0, 5);
+      .slice(0, 8);
   }, [candidates]);
+
+  const filteredCandidates = candidates.filter((candidate) =>
+    `${candidate.candidateName} ${candidate.fileName} ${candidate.topPositions[0]?.role.title ?? ""}`
+      .toLowerCase()
+      .includes(query.toLowerCase())
+  );
+
+  useEffect(() => {
+    void refreshRecords();
+  }, []);
+
+  async function refreshRecords() {
+    const [candidateResponse, analysisResponse, auditResponse] = await Promise.all([
+      fetch("/api/candidates"),
+      fetch("/api/analyses"),
+      fetch("/api/audit")
+    ]);
+
+    if (candidateResponse.ok) {
+      const payload = (await candidateResponse.json()) as { candidates: CandidateAnalysis[] };
+      setCandidates(payload.candidates);
+      setSelectedCandidateId((current) => current || payload.candidates[0]?.id || "");
+    }
+
+    if (analysisResponse.ok) {
+      const payload = (await analysisResponse.json()) as { analyses: AnalysisRecord[] };
+      setAnalyses(payload.analyses);
+    }
+
+    if (auditResponse.ok) {
+      const payload = (await auditResponse.json()) as { events: AuditEvent[] };
+      setAuditEvents(payload.events);
+    }
+  }
 
   function addFiles(fileList: FileList | null) {
     if (!fileList) {
       return;
     }
-    const nextFiles = Array.from(fileList).filter((file) =>
-      /\.(pdf|docx|txt)$/i.test(file.name)
-    );
+    const nextFiles = Array.from(fileList).filter((file) => /\.(pdf|docx|txt)$/i.test(file.name));
     setFiles((current) => [...current, ...nextFiles].slice(0, 12));
   }
 
@@ -83,13 +135,12 @@ export default function Dashboard({ user }: { user: SessionUser }) {
     }
 
     const uploadPayload = payload as UploadResponse;
-    setCandidates(uploadPayload.candidates);
-    setSelectedCandidateId(uploadPayload.candidates[0]?.id ?? "");
+    setCandidates((current) => [...uploadPayload.candidates, ...current]);
+    setSelectedCandidateId(uploadPayload.candidates[0]?.id ?? selectedCandidateId);
     setFailures(uploadPayload.failures);
-    setNotice(
-      `Processed ${uploadPayload.candidates.length} resume${uploadPayload.candidates.length === 1 ? "" : "s"}.`
-    );
+    setNotice(`Processed ${uploadPayload.candidates.length} resume${uploadPayload.candidates.length === 1 ? "" : "s"}.`);
     setIsUploading(false);
+    void refreshRecords();
   }
 
   async function logout() {
@@ -103,31 +154,21 @@ export default function Dashboard({ user }: { user: SessionUser }) {
   return (
     <main className="product-shell">
       <aside className="side-nav" aria-label="Primary">
-        <div className="amazon-mark">a</div>
-        <button className="nav-item active" title="Dashboard">
-          <LayoutDashboard aria-hidden="true" />
-          Dashboard
-        </button>
-        <button className="nav-item" title="Analyses">
-          <BarChart3 aria-hidden="true" />
-          Analyses
-        </button>
-        <button className="nav-item" title="Learning">
-          <BookOpen aria-hidden="true" />
-          Learning
-        </button>
-        <button className="nav-item" title="Workforce">
-          <Users aria-hidden="true" />
-          Workforce
-        </button>
-        <button className="nav-item" title="Audit Log">
-          <ShieldCheck aria-hidden="true" />
-          Audit Log
-        </button>
-        <button className="nav-item" title="Settings">
-          <Settings aria-hidden="true" />
-          Settings
-        </button>
+        <div className="amazon-mark">sm</div>
+        {navItems.map((item) => {
+          const Icon = item.icon;
+          return (
+            <button
+              className={`nav-item ${view === item.id ? "active" : ""}`}
+              key={item.id}
+              onClick={() => setView(item.id)}
+              title={item.label}
+            >
+              <Icon aria-hidden="true" />
+              {item.label}
+            </button>
+          );
+        })}
       </aside>
 
       <section className="main-product">
@@ -148,8 +189,8 @@ export default function Dashboard({ user }: { user: SessionUser }) {
           <div className="audit-status">
             <CheckCircle2 aria-hidden="true" />
             <div>
-              <strong>Audit Status: Compliant</strong>
-              <span>Authenticated as {user.name} ({user.role.replace("_", " ")})</span>
+              <strong>Session Protected</strong>
+              <span>{user.name} ({user.role.replace("_", " ")})</span>
             </div>
           </div>
           <button className="icon-text-button" onClick={logout}>
@@ -158,192 +199,410 @@ export default function Dashboard({ user }: { user: SessionUser }) {
           </button>
         </header>
 
-        <section className="concept-grid">
-          <section className="concept-panel upload-panel">
-            <h2>1. Upload Resumes</h2>
-            <div
-              className="drop-zone"
-              onDrop={(event) => {
-                event.preventDefault();
-                addFiles(event.dataTransfer.files);
-              }}
-              onDragOver={(event) => event.preventDefault()}
-            >
-              <UploadCloud aria-hidden="true" />
-              <strong>Drop PDF or DOCX resumes here</strong>
-              <span>or click to browse</span>
-              <input
-                aria-label="Upload resume files"
-                type="file"
-                multiple
-                accept=".pdf,.docx,.txt,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-                onChange={(event) => addFiles(event.target.files)}
-              />
-            </div>
-            <ul className="file-list">
-              {files.map((file) => (
-                <li key={`${file.name}-${file.size}`}>
-                  <CheckCircle2 aria-hidden="true" />
-                  <span>{file.name}</span>
-                  <small>{Math.round(file.size / 1024)} KB</small>
-                </li>
-              ))}
-            </ul>
-            <div className="role-facts">
-              <h3>2. Target Internal Role</h3>
-              <p>Job Family: {selectedRole.family}</p>
-              <p>Business Unit: {selectedRole.department}</p>
-            </div>
-            {notice ? <p className="notice">{notice}</p> : null}
-            {failures.map((failure) => (
-              <p className="error-message" key={failure.fileName}>
-                {failure.fileName}: {failure.error}
-              </p>
-            ))}
-            <button className="run-button" onClick={uploadResumes} disabled={isUploading}>
-              <SlidersHorizontal aria-hidden="true" />
-              {isUploading ? "Processing resumes..." : "Run SkillMatch Analysis"}
-            </button>
-          </section>
+        {view === "dashboard" ? (
+          <>
+            <section className="concept-grid">
+              <section className="concept-panel upload-panel">
+                <h2>1. Upload Resumes</h2>
+                <div
+                  className="drop-zone"
+                  onDrop={(event) => {
+                    event.preventDefault();
+                    addFiles(event.dataTransfer.files);
+                  }}
+                  onDragOver={(event) => event.preventDefault()}
+                >
+                  <UploadCloud aria-hidden="true" />
+                  <strong>Drop PDF, DOCX, or TXT resumes here</strong>
+                  <span>or click to browse</span>
+                  <input
+                    aria-label="Upload resume files"
+                    type="file"
+                    multiple
+                    accept=".pdf,.docx,.txt,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,text/plain"
+                    onChange={(event) => addFiles(event.target.files)}
+                  />
+                </div>
+                <ul className="file-list">
+                  {files.map((file) => (
+                    <li key={`${file.name}-${file.size}`}>
+                      <CheckCircle2 aria-hidden="true" />
+                      <span>{file.name}</span>
+                      <small>{Math.round(file.size / 1024)} KB</small>
+                    </li>
+                  ))}
+                </ul>
+                <div className="role-facts">
+                  <h3>2. Target Internal Role</h3>
+                  <p>Job Family: {selectedRole.family}</p>
+                  <p>Business Unit: {selectedRole.department}</p>
+                  <p>Level: {selectedRole.level}</p>
+                </div>
+                {notice ? <p className="notice">{notice}</p> : null}
+                {failures.map((failure) => (
+                  <p className="error-message" key={failure.fileName}>
+                    {failure.fileName}: {failure.error}
+                  </p>
+                ))}
+                <button className="run-button" onClick={uploadResumes} disabled={isUploading}>
+                  <SlidersHorizontal aria-hidden="true" />
+                  {isUploading ? "Processing resumes..." : "Run SkillMatch Analysis"}
+                </button>
+              </section>
 
-          <section className="concept-panel overview-panel">
-            <div className="panel-heading">
-              <h2>Skill Match Overview</h2>
-              {selectedCandidate ? <span>{selectedCandidate.candidateName}</span> : null}
-            </div>
-            <div className="overview-content">
-              <div className="score-column">
-                <div className="score-ring large" style={{ "--score": `${bestRecommendation?.score ?? 0}%` } as React.CSSProperties}>
-                  <strong>{bestRecommendation?.score ?? 0}%</strong>
+              <section className="concept-panel overview-panel">
+                <div className="panel-heading">
+                  <h2>Skill Match Overview</h2>
+                  {selectedCandidate ? <span>{selectedCandidate.candidateName}</span> : null}
                 </div>
-                <strong>Overall Match</strong>
-                <span>{bestRecommendation ? bestRecommendation.role.title : "Upload resumes to rank positions"}</span>
-              </div>
-              <div className="skill-columns">
-                <div>
-                  <h3>
-                    <CheckCircle2 aria-hidden="true" />
-                    Top Matched Skills
-                  </h3>
-                  <ul className="match-table">
-                    {matchedSkills.slice(0, 8).map((skill) => (
-                      <li key={skill}>
-                        <span>{skill}</span>
-                        <small>Strong</small>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-                <div>
-                  <h3>
-                    <AlertTriangle aria-hidden="true" />
-                    Missing Skills
-                  </h3>
-                  <ul className="gap-table">
-                    {missingSkills.slice(0, 8).map((gap) => (
-                      <li key={gap.skill}>
-                        <span>{gap.skill}</span>
-                        <small>{gap.importance}</small>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <aside className="right-stack">
-            <section className="concept-panel">
-              <div className="panel-heading">
-                <h2>Recommended Positions</h2>
-                <span>Prioritized</span>
-              </div>
-              <ol className="recommendation-list">
-                {(selectedCandidate?.topPositions ?? []).slice(0, 5).map((recommendation) => (
-                  <li key={recommendation.role.id}>
-                    <b>{recommendation.rank}</b>
-                    <div>
-                      <strong>{recommendation.role.title}</strong>
-                      <span>{recommendation.role.department}</span>
+                <div className="overview-content">
+                  <div className="score-column">
+                    <div className="score-ring large" style={{ "--score": `${bestRecommendation?.score ?? 0}%` } as CSSProperties}>
+                      <strong>{bestRecommendation?.score ?? 0}%</strong>
                     </div>
-                    <em>{recommendation.score}%</em>
-                  </li>
+                    <strong>Overall Match</strong>
+                    <span>{bestRecommendation ? bestRecommendation.role.title : "Upload resumes to rank positions"}</span>
+                  </div>
+                  <div className="skill-columns">
+                    <SkillList title="Top Matched Skills" items={matchedSkills.slice(0, 8)} />
+                    <GapList gaps={missingSkills.slice(0, 8)} />
+                  </div>
+                </div>
+              </section>
+
+              <aside className="right-stack">
+                <RecommendationPanel candidate={selectedCandidate} />
+                <RecentCandidates candidates={candidates} onSelect={setSelectedCandidateId} />
+              </aside>
+            </section>
+            <BottomPanels user={user} selectedRole={selectedRole} workforceGaps={workforceGaps} isUploading={isUploading} files={files} />
+          </>
+        ) : null}
+
+        {view === "analyses" ? (
+          <section className="screen-stack">
+            <div className="screen-toolbar">
+              <label className="search-box">
+                <Search aria-hidden="true" />
+                <input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Search candidates" />
+              </label>
+              <button className="icon-text-button" onClick={() => void refreshRecords()}>Refresh</button>
+            </div>
+            <section className="data-grid">
+              {filteredCandidates.map((candidate) => (
+                <article className="candidate-card" key={candidate.id}>
+                  <div className="panel-heading">
+                    <h2>{candidate.candidateName}</h2>
+                    <span>{candidate.topPositions[0]?.score ?? 0}%</span>
+                  </div>
+                  <p>{candidate.fileName}</p>
+                  <strong>{candidate.topPositions[0]?.role.title ?? "No recommendation"}</strong>
+                  <small>{candidate.topPositions[0]?.explanation}</small>
+                </article>
+              ))}
+              {!filteredCandidates.length ? <EmptyPanel title="No candidate analyses yet" text="Upload resumes from the dashboard to populate this screen." /> : null}
+            </section>
+            <HistoryTable analyses={analyses} />
+          </section>
+        ) : null}
+
+        {view === "learning" ? (
+          <section className="screen-stack">
+            <section className="concept-panel">
+              <div className="panel-heading">
+                <h2>Learning Recommendations</h2>
+                <span>{selectedRole.title}</span>
+              </div>
+              <div className="learning-grid">
+                {Object.entries(selectedRole.learning).map(([skill, course]) => (
+                  <article className="learning-item" key={skill}>
+                    <GraduationCap aria-hidden="true" />
+                    <div>
+                      <strong>{course}</strong>
+                      <span>{skill}</span>
+                    </div>
+                  </article>
                 ))}
-              </ol>
+              </div>
+            </section>
+          </section>
+        ) : null}
+
+        {view === "workforce" ? (
+          <section className="screen-stack">
+            <section className="metric-grid">
+              <Metric label="Open role families" value={roles.length} />
+              <Metric label="Candidates reviewed" value={candidates.length} />
+              <Metric label="Tracked skill gaps" value={workforceGaps.length || selectedRole.requiredSkills.length} />
             </section>
             <section className="concept-panel">
               <div className="panel-heading">
-                <h2>Recent Analyses</h2>
-                <span>{candidates.length}</span>
+                <h2>Role Coverage Matrix</h2>
+                <span>Current catalog</span>
               </div>
-              <ul className="recent-list">
-                {candidates.slice(0, 4).map((candidate) => (
-                  <li key={candidate.id}>
-                    <button onClick={() => setSelectedCandidateId(candidate.id)}>
-                      <FileText aria-hidden="true" />
-                      <span>
-                        <strong>{candidate.candidateName}</strong>
-                        {candidate.topPositions[0]?.role.title}
-                      </span>
-                      <ChevronRight aria-hidden="true" />
-                    </button>
-                  </li>
+              <div className="role-matrix">
+                {roles.map((role) => (
+                  <article key={role.id}>
+                    <strong>{role.title}</strong>
+                    <span>{role.department}</span>
+                    <small>{role.requiredSkills.slice(0, 5).join(", ")}</small>
+                  </article>
                 ))}
-              </ul>
+              </div>
             </section>
-          </aside>
-        </section>
+            <BottomPanels user={user} selectedRole={selectedRole} workforceGaps={workforceGaps} isUploading={isUploading} files={files} />
+          </section>
+        ) : null}
 
-        <section className="bottom-grid">
-          <section className="concept-panel audit-log-panel">
-            <h2>Recruiter / Admin Audit Log</h2>
-            <div className="audit-log-table">
-              <div className="audit-log-row head">
-                <span>Date & Time</span>
-                <span>Action</span>
-                <span>User</span>
-                <span>Status</span>
+        {view === "audit" ? (
+          <section className="screen-stack">
+            <section className="concept-panel audit-log-panel">
+              <div className="panel-heading">
+                <h2>Audit Log</h2>
+                <span>{user.role === "system_admin" ? `${auditEvents.length} events` : "Admin only"}</span>
               </div>
-              <div className="audit-log-row">
-                <span>Current session</span>
-                <span>Recommendation generation</span>
-                <span>{user.email}</span>
-                <span className="status-chip">Compliant</span>
-              </div>
-              <div className="audit-log-row">
-                <span>Current session</span>
-                <span>RBAC session active</span>
+              {user.role === "system_admin" ? <AuditTable events={auditEvents} /> : <EmptyPanel title="Restricted screen" text="System administrators can view login, upload, and override events." />}
+            </section>
+          </section>
+        ) : null}
+
+        {view === "settings" ? (
+          <section className="screen-stack">
+            <section className="concept-panel settings-grid">
+              <div>
+                <h2>Account</h2>
+                <p>{user.name}</p>
+                <strong>{user.email}</strong>
                 <span>{user.role.replace("_", " ")}</span>
-                <span className="status-chip">Protected</span>
               </div>
-            </div>
+              <div>
+                <h2>MVP Controls</h2>
+                <p>Credential users are loaded from AUTH_USERS_JSON.</p>
+                <p>Session lifetime is eight hours.</p>
+                <p>Database storage activates when DATABASE_URL is present.</p>
+              </div>
+            </section>
           </section>
-
-          <section className="concept-panel workforce-panel">
-            <div className="panel-heading">
-              <h2>Workforce Gap Report</h2>
-              <span>{selectedRole.title}</span>
-            </div>
-            <div className="gap-bars">
-              {(workforceGaps.length ? workforceGaps : [["system design", 3], ["kubernetes", 2], ["docker", 2]]).map(
-                ([skill, count]) => (
-                  <div key={skill}>
-                    <span>{skill}</span>
-                    <meter value={Number(count)} min={0} max={Math.max(candidates.length, 3)} />
-                    <strong>{Number(count)}</strong>
-                  </div>
-                )
-              )}
-            </div>
-            <div className="system-health">
-              <Activity aria-hidden="true" />
-              <span>API healthy</span>
-              <span>Queue backlog: {isUploading ? files.length : 0}</span>
-              <span>Retry policy: enabled</span>
-            </div>
-          </section>
-        </section>
+        ) : null}
       </section>
     </main>
+  );
+}
+
+function SkillList({ title, items }: { title: string; items: string[] }) {
+  return (
+    <div>
+      <h3>
+        <CheckCircle2 aria-hidden="true" />
+        {title}
+      </h3>
+      <ul className="match-table">
+        {items.map((skill) => (
+          <li key={skill}>
+            <span>{skill}</span>
+            <small>Strong</small>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function GapList({ gaps }: { gaps: CandidateAnalysis["topPositions"][number]["missingSkills"] }) {
+  return (
+    <div>
+      <h3>
+        <AlertTriangle aria-hidden="true" />
+        Missing Skills
+      </h3>
+      <ul className="gap-table">
+        {gaps.map((gap) => (
+          <li key={gap.skill}>
+            <span>{gap.skill}</span>
+            <small>{gap.importance}</small>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function RecommendationPanel({ candidate }: { candidate?: CandidateAnalysis }) {
+  return (
+    <section className="concept-panel">
+      <div className="panel-heading">
+        <h2>Recommended Positions</h2>
+        <span>Prioritized</span>
+      </div>
+      <ol className="recommendation-list">
+        {(candidate?.topPositions ?? []).slice(0, 5).map((recommendation) => (
+          <li key={recommendation.role.id}>
+            <b>{recommendation.rank}</b>
+            <div>
+              <strong>{recommendation.role.title}</strong>
+              <span>{recommendation.role.department}</span>
+            </div>
+            <em>{recommendation.score}%</em>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+function RecentCandidates({ candidates, onSelect }: { candidates: CandidateAnalysis[]; onSelect: (id: string) => void }) {
+  return (
+    <section className="concept-panel">
+      <div className="panel-heading">
+        <h2>Recent Analyses</h2>
+        <span>{candidates.length}</span>
+      </div>
+      <ul className="recent-list">
+        {candidates.slice(0, 4).map((candidate) => (
+          <li key={candidate.id}>
+            <button onClick={() => onSelect(candidate.id)}>
+              <FileText aria-hidden="true" />
+              <span>
+                <strong>{candidate.candidateName}</strong>
+                {candidate.topPositions[0]?.role.title}
+              </span>
+              <ChevronRight aria-hidden="true" />
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function BottomPanels({
+  user,
+  selectedRole,
+  workforceGaps,
+  isUploading,
+  files
+}: {
+  user: SessionUser;
+  selectedRole: (typeof roles)[number];
+  workforceGaps: Array<[string, number]>;
+  isUploading: boolean;
+  files: File[];
+}) {
+  return (
+    <section className="bottom-grid">
+      <section className="concept-panel audit-log-panel">
+        <h2>Recruiter / Admin Audit Snapshot</h2>
+        <div className="audit-log-table">
+          <div className="audit-log-row head">
+            <span>Date & Time</span>
+            <span>Action</span>
+            <span>User</span>
+            <span>Status</span>
+          </div>
+          <div className="audit-log-row">
+            <span>Current session</span>
+            <span>Recommendation generation</span>
+            <span>{user.email}</span>
+            <span className="status-chip">Compliant</span>
+          </div>
+          <div className="audit-log-row">
+            <span>Current session</span>
+            <span>RBAC session active</span>
+            <span>{user.role.replace("_", " ")}</span>
+            <span className="status-chip">Protected</span>
+          </div>
+        </div>
+      </section>
+
+      <section className="concept-panel workforce-panel">
+        <div className="panel-heading">
+          <h2>Workforce Gap Report</h2>
+          <span>{selectedRole.title}</span>
+        </div>
+        <div className="gap-bars">
+          {(workforceGaps.length ? workforceGaps : selectedRole.requiredSkills.slice(0, 5).map((skill, index) => [skill, 5 - index] as [string, number])).map(
+            ([skill, count]) => (
+              <div key={skill}>
+                <span>{skill}</span>
+                <meter value={Number(count)} min={0} max={Math.max(files.length, 5)} />
+                <strong>{Number(count)}</strong>
+              </div>
+            )
+          )}
+        </div>
+        <div className="system-health">
+          <Activity aria-hidden="true" />
+          <span>API healthy</span>
+          <span>Queue backlog: {isUploading ? files.length : 0}</span>
+          <span>Retry policy: enabled</span>
+        </div>
+      </section>
+    </section>
+  );
+}
+
+function EmptyPanel({ title, text }: { title: string; text: string }) {
+  return (
+    <article className="concept-panel empty-panel">
+      <h2>{title}</h2>
+      <p>{text}</p>
+    </article>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number | string }) {
+  return (
+    <article className="concept-panel metric-card">
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </article>
+  );
+}
+
+function HistoryTable({ analyses }: { analyses: AnalysisRecord[] }) {
+  return (
+    <section className="concept-panel audit-log-panel">
+      <div className="panel-heading">
+        <h2>Analysis History</h2>
+        <span>{analyses.length}</span>
+      </div>
+      <div className="audit-log-table">
+        <div className="audit-log-row head">
+          <span>Candidate</span>
+          <span>Target Role</span>
+          <span>Score</span>
+          <span>Created</span>
+        </div>
+        {analyses.map((analysis) => (
+          <div className="audit-log-row" key={analysis.id}>
+            <span>{analysis.employeeName}</span>
+            <span>{analysis.targetRole}</span>
+            <span className="status-chip">{analysis.score}%</span>
+            <span>{new Date(analysis.createdAt).toLocaleDateString()}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function AuditTable({ events }: { events: AuditEvent[] }) {
+  return (
+    <div className="audit-log-table">
+      <div className="audit-log-row head">
+        <span>Date & Time</span>
+        <span>Action</span>
+        <span>Actor</span>
+        <span>Status</span>
+      </div>
+      {events.map((event) => (
+        <div className="audit-log-row" key={event.id}>
+          <span>{new Date(event.createdAt).toLocaleString()}</span>
+          <span>{event.action.replaceAll("_", " ")}</span>
+          <span>{event.actor}</span>
+          <span className="status-chip">Recorded</span>
+        </div>
+      ))}
+    </div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -583,6 +583,140 @@ meter {
   font-weight: 800;
 }
 
+.screen-stack {
+  display: grid;
+  gap: 12px;
+}
+
+.screen-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.search-box {
+  display: grid;
+  grid-template-columns: 20px minmax(220px, 420px);
+  align-items: center;
+  gap: 8px;
+  min-height: 42px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: white;
+  padding: 0 12px;
+  color: var(--muted);
+}
+
+.search-box input {
+  min-height: 38px;
+  border: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.data-grid,
+.learning-grid,
+.metric-grid,
+.role-matrix {
+  display: grid;
+  gap: 12px;
+}
+
+.data-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.candidate-card,
+.learning-item,
+.metric-card,
+.role-matrix article {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: white;
+  box-shadow: var(--shadow);
+}
+
+.candidate-card {
+  display: grid;
+  gap: 10px;
+  min-height: 210px;
+  padding: 18px;
+}
+
+.candidate-card p,
+.candidate-card small,
+.empty-panel p,
+.settings-grid p,
+.settings-grid span,
+.learning-item span,
+.role-matrix span,
+.role-matrix small,
+.metric-card span {
+  color: var(--muted);
+}
+
+.candidate-card small {
+  line-height: 1.45;
+}
+
+.learning-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.learning-item {
+  display: grid;
+  grid-template-columns: 30px 1fr;
+  align-items: center;
+  gap: 12px;
+  min-height: 86px;
+  padding: 16px;
+}
+
+.learning-item svg {
+  color: #1f6fd1;
+}
+
+.learning-item div,
+.settings-grid > div,
+.role-matrix article,
+.metric-card {
+  display: grid;
+  gap: 6px;
+}
+
+.metric-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.metric-card {
+  padding: 18px;
+}
+
+.metric-card strong {
+  font-size: 34px;
+}
+
+.role-matrix {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.role-matrix article {
+  padding: 16px;
+}
+
+.settings-grid {
+  display: grid;
+  grid-template-columns: 0.8fr 1.2fr;
+  gap: 28px;
+}
+
+.empty-panel {
+  display: grid;
+  align-content: center;
+  min-height: 180px;
+}
+
 .login-shell {
   display: grid;
   min-height: 100vh;
@@ -628,7 +762,12 @@ meter {
   }
 
   .concept-grid,
-  .bottom-grid {
+  .bottom-grid,
+  .data-grid,
+  .learning-grid,
+  .metric-grid,
+  .role-matrix,
+  .settings-grid {
     grid-template-columns: 1fr;
   }
 
@@ -647,8 +786,14 @@ meter {
   .overview-content,
   .skill-columns,
   .audit-log-row,
-  .system-health {
+  .system-health,
+  .screen-toolbar,
+  .search-box {
     grid-template-columns: 1fr;
+  }
+
+  .screen-toolbar {
+    display: grid;
   }
 
   .brand-block {

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,22 +1,32 @@
 "use client";
 
+import { useState } from "react";
 import { ShieldCheck } from "lucide-react";
-import { demoUsers } from "@/lib/auth-model";
 
 export default function LoginPage() {
+  const [error, setError] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
   async function login(formData: FormData) {
+    setError("");
+    setIsSubmitting(true);
     const response = await fetch("/api/auth/login", {
       method: "POST",
       body: JSON.stringify({
         email: String(formData.get("email") ?? ""),
-        role: String(formData.get("role") ?? "")
+        password: String(formData.get("password") ?? "")
       }),
       headers: { "Content-Type": "application/json" }
     });
 
     if (response.ok) {
       window.location.href = "/";
+      return;
     }
+
+    const payload = (await response.json()) as { error?: string };
+    setError(payload.error ?? "Sign in failed.");
+    setIsSubmitting(false);
   }
 
   return (
@@ -26,31 +36,20 @@ export default function LoginPage() {
           <ShieldCheck aria-hidden="true" />
           <span>SkillMatch AI</span>
         </div>
-        <h1>Amazon SSO access</h1>
-        <p>Demo single sign-on gate for internal users and role-based access control.</p>
+        <h1>Secure sign in</h1>
+        <p>Use the demo credentials configured for this environment.</p>
 
         <label>
-          Internal account
-          <select name="email" defaultValue={demoUsers[0].email}>
-            {demoUsers.map((user) => (
-              <option key={user.email} value={user.email}>
-                {user.name} - {user.email}
-              </option>
-            ))}
-          </select>
+          Email
+          <input name="email" type="email" autoComplete="email" placeholder="recruiter@skillmatch.demo" required />
         </label>
         <label>
-          Role claim
-          <select name="role" defaultValue={demoUsers[0].role}>
-            {demoUsers.map((user) => (
-              <option key={user.role} value={user.role}>
-                {user.role.replace("_", " ")}
-              </option>
-            ))}
-          </select>
+          Password
+          <input name="password" type="password" autoComplete="current-password" required />
         </label>
-        <button className="primary-action" type="submit">
-          Sign in with Amazon
+        {error ? <p className="error-message" role="alert">{error}</p> : null}
+        <button className="primary-action" type="submit" disabled={isSubmitting}>
+          {isSubmitting ? "Signing in..." : "Sign in"}
         </button>
       </form>
     </main>

--- a/lib/auth-model.ts
+++ b/lib/auth-model.ts
@@ -1,3 +1,5 @@
+import crypto from "node:crypto";
+
 export type UserRole =
   | "employee"
   | "recruiter"
@@ -11,9 +13,84 @@ export type SessionUser = {
   role: UserRole;
 };
 
-export const demoUsers: SessionUser[] = [
-  { name: "Alex Smith", email: "alex.smith@amazon.com", role: "employee" },
-  { name: "Priya Recruiter", email: "priya.recruiter@amazon.com", role: "recruiter" },
-  { name: "Yash Admin", email: "yash.admin@amazon.com", role: "system_admin" },
-  { name: "Lina L&D", email: "lina.learning@amazon.com", role: "learning_development" }
+export type CredentialUser = SessionUser & {
+  password?: string;
+  passwordHash?: string;
+};
+
+const fallbackCredentialUsers: CredentialUser[] = [
+  {
+    name: "Priya Recruiter",
+    email: "recruiter@skillmatch.demo",
+    role: "recruiter",
+    password: "SkillMatchDemo!23"
+  },
+  {
+    name: "Yash Admin",
+    email: "admin@skillmatch.demo",
+    role: "system_admin",
+    password: "SkillMatchAdmin!23"
+  },
+  {
+    name: "Lina L&D",
+    email: "learning@skillmatch.demo",
+    role: "learning_development",
+    password: "SkillMatchLearn!23"
+  }
 ];
+
+export function createPasswordHash(password: string, salt = crypto.randomBytes(16).toString("base64url")) {
+  const key = crypto.scryptSync(password, salt, 64).toString("base64url");
+  return `scrypt$${salt}$${key}`;
+}
+
+function verifyPasswordHash(password: string, passwordHash: string) {
+  const [algorithm, salt, storedKey] = passwordHash.split("$");
+  if (algorithm !== "scrypt" || !salt || !storedKey) {
+    return false;
+  }
+
+  const actual = Buffer.from(crypto.scryptSync(password, salt, 64).toString("base64url"));
+  const expected = Buffer.from(storedKey);
+  return actual.length === expected.length && crypto.timingSafeEqual(actual, expected);
+}
+
+export function getCredentialUsers() {
+  const configuredUsers = process.env.AUTH_USERS_JSON;
+  if (!configuredUsers) {
+    return fallbackCredentialUsers;
+  }
+
+  try {
+    const parsed = JSON.parse(configuredUsers) as CredentialUser[];
+    return parsed.filter((user) => user.email && user.name && user.role && (user.password || user.passwordHash));
+  } catch {
+    return [];
+  }
+}
+
+export async function verifyCredentials(email: string, password: string): Promise<SessionUser | null> {
+  const normalizedEmail = email.trim().toLowerCase();
+  const user = getCredentialUsers().find((item) => item.email.toLowerCase() === normalizedEmail);
+
+  if (!user || !password) {
+    return null;
+  }
+
+  const suppliedPassword = Buffer.from(password);
+  const expectedPassword = Buffer.from(user.password ?? "");
+  const verified = user.passwordHash
+    ? verifyPasswordHash(password, user.passwordHash)
+    : suppliedPassword.length === expectedPassword.length &&
+      crypto.timingSafeEqual(suppliedPassword, expectedPassword);
+
+  if (!verified) {
+    return null;
+  }
+
+  return {
+    name: user.name,
+    email: user.email,
+    role: user.role
+  };
+}

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { canAccess, createSessionToken, parseSessionToken } from "@/lib/auth";
-import type { SessionUser } from "@/lib/auth-model";
+import { createPasswordHash, verifyCredentials, type SessionUser } from "@/lib/auth-model";
 
 const admin: SessionUser = {
   name: "Admin",
@@ -23,5 +23,24 @@ describe("auth and RBAC", () => {
     expect(canAccess(admin, "admin")).toBe(true);
     expect(canAccess({ ...admin, role: "employee" }, "admin")).toBe(false);
     expect(canAccess({ ...admin, role: "recruiter" }, "recruiter")).toBe(true);
+  });
+
+  it("verifies configured credential users", async () => {
+    process.env.AUTH_USERS_JSON = JSON.stringify([
+      {
+        name: "Demo Admin",
+        email: "admin@example.com",
+        role: "system_admin",
+        passwordHash: createPasswordHash("correct-password", "test-salt")
+      }
+    ]);
+
+    await expect(verifyCredentials("admin@example.com", "correct-password")).resolves.toEqual({
+      name: "Demo Admin",
+      email: "admin@example.com",
+      role: "system_admin"
+    });
+    await expect(verifyCredentials("admin@example.com", "wrong-password")).resolves.toBeNull();
+    delete process.env.AUTH_USERS_JSON;
   });
 });

--- a/tests/e2e/skillmatch.spec.ts
+++ b/tests/e2e/skillmatch.spec.ts
@@ -26,7 +26,9 @@ test("requires SSO, uploads a PDF resume, and ranks positions", async ({ page })
   await page.goto("/");
   await expect(page).toHaveURL(/\/login$/);
 
-  await page.getByRole("button", { name: /sign in with amazon/i }).click();
+  await page.getByLabel("Email").fill("recruiter@skillmatch.demo");
+  await page.getByLabel("Password").fill("SkillMatchDemo!23");
+  await page.getByRole("button", { name: /^sign in$/i }).click();
   await expect(page.getByRole("heading", { name: "SkillMatch AI" })).toBeVisible();
 
   await page.getByLabel("Upload resume files").setInputFiles(resumePath);


### PR DESCRIPTION
## Summary

- Replace predetermined-account login with email/password credential verification backed by `AUTH_USERS_JSON` and fallback demo users.
- Add secure login UI, invalid-login audit events, and password hash support.
- Turn the MVP shell sidebar into navigable screens for dashboard, analyses, learning, workforce, audit log, and settings.
- Wire available screens to existing candidates, analyses, and audit APIs.
- Update auth and Playwright tests for credential-based sign-in.

## Impact

Demo users can now sign in with actual credentials, and stakeholders can review the broader MVP surface instead of only the dashboard.

## Validation

- `git diff --check` passed.
- Unit/e2e/lint/build commands could not be run in this worktree because `npm` is not installed on PATH and the repo has no local `node_modules`; `node --run test` fails because `vitest` is not installed locally.