### PR TITLE
[codex] Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    name: Lint, test, and build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Run unit tests
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Run end-to-end tests
+        run: npm run test:e2e


### PR DESCRIPTION
## What changed
- Added a GitHub Actions CI workflow for pull requests and pushes to `main`.
- The workflow installs dependencies with `npm ci`, installs Chromium for Playwright, then runs lint, unit tests, build, and end-to-end tests.

## Why
This gives the project a basic automated check that verifies code quality, build health, and the existing test suite before changes land.

## Testing
- Could not run local npm checks in this desktop environment because `npm`/`npx` are not installed on PATH.
- Inspected project scripts and environment fallbacks to align CI with the existing npm workflow.