### PR TITLE
Harden session token validation

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -71,13 +71,18 @@ function isSignedSessionPayload(value: unknown): value is SignedSessionPayload {
 
   const session = value as Partial<SignedSessionPayload>;
 
+  const issuedAt = session.iat;
+  const expiresAt = session.exp;
+
   return (
     typeof session.name === "string" &&
     typeof session.email === "string" &&
     typeof session.role === "string" &&
-    Number.isInteger(session.iat) &&
-    Number.isInteger(session.exp) &&
-    session.iat <= session.exp
+    typeof issuedAt === "number" &&
+    typeof expiresAt === "number" &&
+    Number.isInteger(issuedAt) &&
+    Number.isInteger(expiresAt) &&
+    issuedAt <= expiresAt
   );
 }
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -3,17 +3,92 @@ import crypto from "node:crypto";
 import type { SessionUser } from "./auth-model";
 
 const cookieName = "skillmatch_session";
+const localDemoSecret = "skillmatch-ai-local-demo-secret";
+const sessionMaxAgeSeconds = 60 * 60 * 8;
+
+type SignedSessionPayload = SessionUser & {
+  iat: number;
+  exp: number;
+};
 
 function secret() {
-  return process.env.AUTH_SECRET ?? "skillmatch-ai-local-demo-secret";
+  const configuredSecret = process.env.AUTH_SECRET?.trim();
+
+  if (configuredSecret) {
+    if (!allowsLocalDemoSecret() && !isStrongSecret(configuredSecret)) {
+      throw new Error("AUTH_SECRET must be a strong random value of at least 32 characters in production.");
+    }
+
+    return configuredSecret;
+  }
+
+  if (!allowsLocalDemoSecret()) {
+    throw new Error("AUTH_SECRET must be set to a strong random value in production.");
+  }
+
+  return localDemoSecret;
+}
+
+function allowsLocalDemoSecret() {
+  return process.env.NODE_ENV !== "production";
+}
+
+function isStrongSecret(value: string) {
+  const weakSecrets = new Set([
+    localDemoSecret,
+    "replace-with-a-long-random-secret",
+    "changeme",
+    "password",
+    "secret"
+  ]);
+
+  return value.length >= 32 && new Set(value).size >= 8 && !weakSecrets.has(value.toLowerCase());
 }
 
 function sign(payload: string) {
   return crypto.createHmac("sha256", secret()).update(payload).digest("hex");
 }
 
+function signaturesMatch(payload: string, signature: string) {
+  if (!/^[a-f0-9]{64}$/i.test(signature)) {
+    return false;
+  }
+
+  const expected = Buffer.from(sign(payload), "hex");
+  const actual = Buffer.from(signature, "hex");
+
+  return expected.length === actual.length && crypto.timingSafeEqual(expected, actual);
+}
+
+function nowInSeconds() {
+  return Math.floor(Date.now() / 1000);
+}
+
+function isSignedSessionPayload(value: unknown): value is SignedSessionPayload {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const session = value as Partial<SignedSessionPayload>;
+
+  return (
+    typeof session.name === "string" &&
+    typeof session.email === "string" &&
+    typeof session.role === "string" &&
+    Number.isInteger(session.iat) &&
+    Number.isInteger(session.exp) &&
+    session.iat <= session.exp
+  );
+}
+
 export function createSessionToken(user: SessionUser) {
-  const payload = Buffer.from(JSON.stringify(user), "utf8").toString("base64url");
+  const issuedAt = nowInSeconds();
+  const signedPayload: SignedSessionPayload = {
+    ...user,
+    iat: issuedAt,
+    exp: issuedAt + sessionMaxAgeSeconds
+  };
+  const payload = Buffer.from(JSON.stringify(signedPayload), "utf8").toString("base64url");
   return `${payload}.${sign(payload)}`;
 }
 
@@ -22,13 +97,27 @@ export function parseSessionToken(token?: string): SessionUser | null {
     return null;
   }
 
-  const [payload, signature] = token.split(".");
-  if (!payload || !signature || sign(payload) !== signature) {
+  const parts = token.split(".");
+  if (parts.length !== 2) {
+    return null;
+  }
+
+  const [payload, signature] = parts;
+  if (!payload || !signature || !signaturesMatch(payload, signature)) {
     return null;
   }
 
   try {
-    return JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as SessionUser;
+    const session = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as unknown;
+    if (!isSignedSessionPayload(session) || session.exp <= nowInSeconds()) {
+      return null;
+    }
+
+    return {
+      name: session.name,
+      email: session.email,
+      role: session.role
+    };
   } catch {
     return null;
   }
@@ -46,7 +135,7 @@ export async function setSessionUser(user: SessionUser) {
     sameSite: "lax",
     secure: process.env.NODE_ENV === "production",
     path: "/",
-    maxAge: 60 * 60 * 8
+    maxAge: sessionMaxAgeSeconds
   });
 }
 

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { canAccess, createSessionToken, parseSessionToken } from "@/lib/auth";
 import { createPasswordHash, verifyCredentials, type SessionUser } from "@/lib/auth-model";
 
@@ -8,15 +8,75 @@ const admin: SessionUser = {
   role: "system_admin"
 };
 
+const originalAuthSecret = process.env.AUTH_SECRET;
+const originalNodeEnv = process.env.NODE_ENV;
+
+beforeEach(() => {
+  delete process.env.AUTH_SECRET;
+  process.env.NODE_ENV = "test";
+  vi.useRealTimers();
+});
+
+afterEach(() => {
+  if (originalAuthSecret === undefined) {
+    delete process.env.AUTH_SECRET;
+  } else {
+    process.env.AUTH_SECRET = originalAuthSecret;
+  }
+
+  process.env.NODE_ENV = originalNodeEnv;
+  delete process.env.AUTH_USERS_JSON;
+  vi.useRealTimers();
+});
+
 describe("auth and RBAC", () => {
   it("round-trips signed session tokens", () => {
     const token = createSessionToken(admin);
     expect(parseSessionToken(token)).toEqual(admin);
   });
 
+  it("adds issued-at and expiration data to signed session tokens", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+    const token = createSessionToken(admin);
+    const [payload] = token.split(".");
+    const decoded = JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
+
+    expect(decoded).toMatchObject({
+      ...admin,
+      iat: 1767225600,
+      exp: 1767254400
+    });
+  });
+
+  it("rejects expired session tokens", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    const token = createSessionToken(admin);
+
+    vi.setSystemTime(new Date("2026-01-01T08:00:01.000Z"));
+
+    expect(parseSessionToken(token)).toBeNull();
+  });
+
   it("rejects tampered session tokens", () => {
     const token = createSessionToken(admin);
     expect(parseSessionToken(`${token}tampered`)).toBeNull();
+  });
+
+  it("requires AUTH_SECRET in production", () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.AUTH_SECRET;
+
+    expect(() => createSessionToken(admin)).toThrow(/AUTH_SECRET must be set/);
+  });
+
+  it("rejects weak AUTH_SECRET values in production", () => {
+    process.env.NODE_ENV = "production";
+    process.env.AUTH_SECRET = "short-secret";
+
+    expect(() => createSessionToken(admin)).toThrow(/AUTH_SECRET must be a strong random value/);
   });
 
   it("enforces role-based access for admin and recruiter areas", () => {


### PR DESCRIPTION
## What changed
- Added `iat` and `exp` claims to signed session tokens.
- Reject expired, malformed, or tampered session tokens.
- Require a strong `AUTH_SECRET` in production while preserving local/test fallback behavior.
- Added auth tests for expiration and weak/missing production secrets.

## Why
- Session validity should be encoded and enforced inside the signed token, and production deployments should fail closed when session signing is weak or missing.

## How tested
- `npm test -- tests/auth.test.ts`
- `npm test`
- `npm run lint` (passes with one existing warning in `app/api/auth/login/route.ts`)

Closes #9