### PR TITLE
Add explainable skill matching

### DIFF
--- a/lib/seed-data.ts
+++ b/lib/seed-data.ts
@@ -10,6 +10,39 @@ export type RoleRequirement = {
   learning: Record<string, string>;
 };
 
+export type MatchingConfig = {
+  scoringWeights: {
+    required: number;
+    preferred: number;
+  };
+  skillAliases: Record<string, string[]>;
+};
+
+export const matchingConfig: MatchingConfig = {
+  scoringWeights: {
+    required: 2,
+    preferred: 1
+  },
+  skillAliases: {
+    "api design": ["api development", "apis", "rest design", "restful api design"],
+    aws: ["amazon web services"],
+    "ci cd": ["ci/cd", "ci-cd", "continuous integration", "continuous delivery", "continuous deployment"],
+    dashboarding: ["dashboards", "dashboard development", "bi dashboards"],
+    docker: ["dockerized", "containers", "containerization"],
+    excel: ["spreadsheets", "microsoft excel"],
+    git: ["github", "gitlab", "version control"],
+    javascript: ["js"],
+    kubernetes: ["k8s"],
+    node: ["node.js", "nodejs"],
+    postgresql: ["postgres", "postgres sql"],
+    "rest api": ["rest", "restful", "restful api", "rest apis", "rest services"],
+    security: ["cybersecurity", "appsec", "application security"],
+    sql: ["structured query language"],
+    testing: ["tests", "test automation", "unit testing", "vitest"],
+    typescript: ["ts"]
+  }
+};
+
 export const roles: RoleRequirement[] = [
   {
     id: "sde-i",

--- a/lib/skillmatch.ts
+++ b/lib/skillmatch.ts
@@ -1,4 +1,32 @@
-import { roles, type RoleRequirement } from "./seed-data";
+import { matchingConfig, roles, type RoleRequirement } from "./seed-data";
+
+type SkillSource = "required" | "preferred";
+
+export type SkillMatchEvidence = {
+  skill: string;
+  matchedText: string;
+  snippet: string;
+  source: SkillSource;
+  weight: number;
+};
+
+export type SkillMatchExplanationDetails = {
+  weights: typeof matchingConfig.scoringWeights;
+  earnedWeight: number;
+  possibleWeight: number;
+  required: {
+    matched: number;
+    total: number;
+    missing: string[];
+  };
+  preferred: {
+    matched: number;
+    total: number;
+    missing: string[];
+  };
+  evidence: SkillMatchEvidence[];
+  rankingFactors: string[];
+};
 
 export type SkillMatchResult = {
   role: RoleRequirement;
@@ -12,6 +40,7 @@ export type SkillMatchResult = {
   }>;
   score: number;
   explanation: string;
+  explanationDetails: SkillMatchExplanationDetails;
 };
 
 export type StructuredResume = {
@@ -36,11 +65,18 @@ export type CandidateAnalysis = {
   createdAt: string;
 };
 
-const skillVocabulary = Array.from(
-  new Set(
-    roles.flatMap((role) => [...role.requiredSkills, ...role.preferredSkills])
-  )
-).sort((a, b) => b.length - a.length);
+const canonicalSkills = Array.from(
+  new Set(roles.flatMap((role) => [...role.requiredSkills, ...role.preferredSkills]))
+);
+
+const skillVocabulary = canonicalSkills.sort((a, b) => b.length - a.length);
+
+const skillTerms = new Map(
+  canonicalSkills.map((skill) => [
+    skill,
+    Array.from(new Set([skill, ...(matchingConfig.skillAliases[skill] ?? [])]))
+  ])
+);
 
 const certificationPatterns = [
   /aws certified[^,\n.]*/gi,
@@ -59,6 +95,31 @@ export function normalizeResumeText(text: string) {
     .trim();
 }
 
+function termMatchesNormalized(normalizedText: string, term: string) {
+  const normalizedTerm = normalizeResumeText(term).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const flexibleTerm = normalizedTerm.replace(/\\\-/g, "[-\\s]+").replace(/\s+/g, "[-\\s]+");
+  return new RegExp(`(^|\\s)${flexibleTerm}s?(\\s|$)`, "i").test(normalizedText);
+}
+
+function findMatchedTerm(normalizedText: string, skill: string) {
+  return skillTerms.get(skill)?.find((term) => termMatchesNormalized(normalizedText, term)) ?? null;
+}
+
+function findEvidenceSnippet(resumeText: string, terms: string[]) {
+  const segments =
+    resumeText
+      .split(/(?<=[.!?])\s+|\r?\n/)
+      .map((segment) => segment.trim())
+      .filter(Boolean);
+
+  const matchedSegment = segments.find((segment) => {
+    const normalizedSegment = normalizeResumeText(segment);
+    return terms.some((term) => termMatchesNormalized(normalizedSegment, term));
+  });
+
+  return (matchedSegment ?? resumeText.trim()).slice(0, 180);
+}
+
 export function maskDemographicSignals(text: string) {
   return text
     .replace(/^[A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,2}\s*$/gm, "[name masked]")
@@ -69,10 +130,7 @@ export function maskDemographicSignals(text: string) {
 
 export function extractSkills(resumeText: string) {
   const normalized = normalizeResumeText(resumeText);
-  return skillVocabulary.filter((skill) => {
-    const escaped = skill.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    return new RegExp(`(^|\\s)${escaped}(\\s|$)`, "i").test(normalized);
-  });
+  return skillVocabulary.filter((skill) => Boolean(findMatchedTerm(normalized, skill)));
 }
 
 export function extractStructuredResume(resumeText: string): StructuredResume {
@@ -112,13 +170,30 @@ export function analyzeResume(resumeText: string, roleId: string): SkillMatchRes
   const matchedSkills = allRoleSkills.filter((skill) => extracted.has(skill));
   const missingRequired = role.requiredSkills.filter((skill) => !extracted.has(skill));
   const missingPreferred = role.preferredSkills.filter((skill) => !extracted.has(skill));
+  const { required: requiredSkillWeight, preferred: preferredSkillWeight } = matchingConfig.scoringWeights;
 
-  const requiredWeight = role.requiredSkills.length * 2;
-  const preferredWeight = role.preferredSkills.length;
+  const requiredWeight = role.requiredSkills.length * requiredSkillWeight;
+  const preferredWeight = role.preferredSkills.length * preferredSkillWeight;
   const earned =
-    role.requiredSkills.filter((skill) => extracted.has(skill)).length * 2 +
-    role.preferredSkills.filter((skill) => extracted.has(skill)).length;
-  const score = Math.round((earned / (requiredWeight + preferredWeight)) * 100);
+    role.requiredSkills.filter((skill) => extracted.has(skill)).length * requiredSkillWeight +
+    role.preferredSkills.filter((skill) => extracted.has(skill)).length * preferredSkillWeight;
+  const possibleWeight = requiredWeight + preferredWeight;
+  const score = possibleWeight > 0 ? Math.round((earned / possibleWeight) * 100) : 0;
+
+  const normalizedResume = normalizeResumeText(resumeText);
+  const evidence = allRoleSkills
+    .filter((skill) => extracted.has(skill))
+    .map((skill) => {
+      const source: SkillSource = role.requiredSkills.includes(skill) ? "required" : "preferred";
+      const terms = skillTerms.get(skill) ?? [skill];
+      return {
+        skill,
+        matchedText: findMatchedTerm(normalizedResume, skill) ?? skill,
+        snippet: findEvidenceSnippet(resumeText, terms),
+        source,
+        weight: source === "required" ? requiredSkillWeight : preferredSkillWeight
+      };
+    });
 
   const missingSkills = [
     ...missingRequired.map((skill) => ({
@@ -133,6 +208,28 @@ export function analyzeResume(resumeText: string, roleId: string): SkillMatchRes
     }))
   ];
 
+  const explanationDetails: SkillMatchExplanationDetails = {
+    weights: matchingConfig.scoringWeights,
+    earnedWeight: earned,
+    possibleWeight,
+    required: {
+      matched: role.requiredSkills.length - missingRequired.length,
+      total: role.requiredSkills.length,
+      missing: missingRequired
+    },
+    preferred: {
+      matched: role.preferredSkills.length - missingPreferred.length,
+      total: role.preferredSkills.length,
+      missing: missingPreferred
+    },
+    evidence,
+    rankingFactors: [
+      `${role.requiredSkills.length - missingRequired.length}/${role.requiredSkills.length} required skills matched`,
+      `${role.preferredSkills.length - missingPreferred.length}/${role.preferredSkills.length} preferred skills matched`,
+      `${earned}/${possibleWeight} weighted points earned`
+    ]
+  };
+
   return {
     role,
     extractedSkills,
@@ -140,7 +237,8 @@ export function analyzeResume(resumeText: string, roleId: string): SkillMatchRes
     matchedSkills,
     missingSkills,
     score,
-    explanation: `Score is based on weighted overlap with ${role.title}: required skills count twice, preferred skills count once. ${matchedSkills.length} role skills matched and ${missingSkills.length} gaps remain. Demographic contact signals are masked before recommendation review.`
+    explanation: `Score is based on configurable weighted overlap with ${role.title}: required skills count ${requiredSkillWeight}x, preferred skills count ${preferredSkillWeight}x. ${explanationDetails.required.matched} of ${role.requiredSkills.length} required skills and ${explanationDetails.preferred.matched} of ${role.preferredSkills.length} preferred skills matched (${earned}/${possibleWeight} weighted points). Evidence snippets are captured for matched skills, and demographic contact signals are masked before recommendation review.`,
+    explanationDetails
   };
 }
 
@@ -167,7 +265,14 @@ export function rankResumeForPositions(resumeText: string) {
     .sort((a, b) => b.score - a.score)
     .map((result, index) => ({
       ...result,
-      rank: index + 1
+      rank: index + 1,
+      explanationDetails: {
+        ...result.explanationDetails,
+        rankingFactors: [
+          `Rank ${index + 1} of ${roles.length} by weighted skill score`,
+          ...result.explanationDetails.rankingFactors
+        ]
+      }
     })) satisfies CandidatePositionRecommendation[];
 }
 

--- a/tests/skillmatch.test.ts
+++ b/tests/skillmatch.test.ts
@@ -25,7 +25,8 @@ describe("skill matching engine", () => {
     expect(result.score).toBeGreaterThanOrEqual(80);
     expect(result.matchedSkills).toContain("typescript");
     expect(result.missingSkills.map((item) => item.skill)).toContain("aws");
-    expect(result.explanation).toContain("required skills count twice");
+    expect(result.explanation).toContain("required skills count 2x");
+    expect(result.explanationDetails.earnedWeight).toBeGreaterThan(result.matchedSkills.length);
   });
 
   it("ranks good positions for each resume", () => {
@@ -35,6 +36,49 @@ describe("skill matching engine", () => {
 
     expect(recommendations[0].role.id).toBe("sde-ii");
     expect(recommendations[0].score).toBeGreaterThan(70);
+    expect(recommendations[0].explanationDetails.rankingFactors[0]).toContain("Rank 1");
+  });
+
+  it("matches configured skill aliases and equivalent spellings", () => {
+    const result = analyzeResume(
+      "Backend engineer shipping REST services with continuous integration, GitHub, and Amazon Web Services.",
+      "sde-ii"
+    );
+
+    expect(result.matchedSkills).toEqual(expect.arrayContaining(["rest api", "ci cd", "git", "aws"]));
+    expect(result.explanationDetails.evidence).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          skill: "rest api",
+          matchedText: "rest"
+        }),
+        expect.objectContaining({
+          skill: "ci cd",
+          matchedText: "continuous integration"
+        })
+      ])
+    );
+  });
+
+  it("captures evidence snippets for partial skill matches", () => {
+    const result = analyzeResume(
+      "Built executive dashboards in Tableau and maintained spreadsheets for weekly statistics reporting.",
+      "data-analyst"
+    );
+
+    expect(result.matchedSkills).toEqual(expect.arrayContaining(["dashboarding", "excel", "statistics", "tableau"]));
+    expect(result.explanationDetails.evidence.find((item) => item.skill === "dashboarding")?.snippet).toContain(
+      "dashboards"
+    );
+  });
+
+  it("returns a zero score and full gaps when no resume skills match", () => {
+    const result = analyzeResume("Opera performer with culinary training and event hosting experience.", "sde-i");
+
+    expect(result.score).toBe(0);
+    expect(result.matchedSkills).toEqual([]);
+    expect(result.explanationDetails.evidence).toEqual([]);
+    expect(result.missingSkills).toHaveLength(10);
   });
 
   it("extracts structured resume data and masks demographic signals", () => {


### PR DESCRIPTION
## What changed
- Added configurable matching weights and skill aliases.
- Made skill extraction alias-aware for terms like CI/CD, REST services, GitHub, and Amazon Web Services.
- Added evidence snippets and structured explanation details to match results.
- Expanded skill matching tests for aliases, evidence, and no-match resumes.

## Why
- Matching should explain why a role ranked where it did and catch common resume wording variants beyond exact keyword overlap.

## How tested
- `npm test -- --run tests/skillmatch.test.ts`
- `npx tsc --noEmit`
- `npm run lint` (passes with one unrelated existing warning in `app/api/auth/login/route.ts`)

Closes #18