### PR TITLE
Improve upload queue controls

### DIFF
--- a/app/dashboard.tsx
+++ b/app/dashboard.tsx
@@ -17,8 +17,10 @@ import {
   Settings,
   ShieldCheck,
   SlidersHorizontal,
+  Trash2,
   UploadCloud,
   Users,
+  X,
   type LucideIcon
 } from "lucide-react";
 import { roles } from "@/lib/seed-data";
@@ -41,6 +43,10 @@ const navItems: Array<{ id: View; label: string; icon: LucideIcon }> = [
   { id: "audit", label: "Audit Log", icon: ShieldCheck },
   { id: "settings", label: "Settings", icon: Settings }
 ];
+
+function fileKey(file: File) {
+  return `${file.name}-${file.size}-${file.lastModified}`;
+}
 
 export default function Dashboard({ user }: { user: SessionUser }) {
   const [view, setView] = useState<View>("dashboard");
@@ -111,10 +117,35 @@ export default function Dashboard({ user }: { user: SessionUser }) {
       return;
     }
     const nextFiles = Array.from(fileList).filter((file) => /\.(pdf|docx|txt)$/i.test(file.name));
-    setFiles((current) => [...current, ...nextFiles].slice(0, 12));
+    setFiles((current) => {
+      const queued = new Set(current.map(fileKey));
+      const uniqueFiles = nextFiles.filter((file) => {
+        const key = fileKey(file);
+        if (queued.has(key)) {
+          return false;
+        }
+        queued.add(key);
+        return true;
+      });
+      return [...current, ...uniqueFiles].slice(0, 12);
+    });
+  }
+
+  function removeFile(fileToRemove: File) {
+    const removeKey = fileKey(fileToRemove);
+    setFiles((current) => current.filter((file) => fileKey(file) !== removeKey));
+  }
+
+  function clearFiles() {
+    setFiles([]);
   }
 
   async function uploadResumes() {
+    if (!files.length) {
+      setNotice("Select at least one resume before running analysis.");
+      return;
+    }
+
     setIsUploading(true);
     setNotice("");
     setFailures([]);
@@ -138,7 +169,12 @@ export default function Dashboard({ user }: { user: SessionUser }) {
     setCandidates((current) => [...uploadPayload.candidates, ...current]);
     setSelectedCandidateId(uploadPayload.candidates[0]?.id ?? selectedCandidateId);
     setFailures(uploadPayload.failures);
-    setNotice(`Processed ${uploadPayload.candidates.length} resume${uploadPayload.candidates.length === 1 ? "" : "s"}.`);
+    setFiles([]);
+    setNotice(
+      uploadPayload.candidates.length
+        ? `Processed ${uploadPayload.candidates.length} resume${uploadPayload.candidates.length === 1 ? "" : "s"}.`
+        : "No resumes were processed."
+    );
     setIsUploading(false);
     void refreshRecords();
   }
@@ -220,15 +256,35 @@ export default function Dashboard({ user }: { user: SessionUser }) {
                     type="file"
                     multiple
                     accept=".pdf,.docx,.txt,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,text/plain"
-                    onChange={(event) => addFiles(event.target.files)}
+                    onChange={(event) => {
+                      addFiles(event.target.files);
+                      event.currentTarget.value = "";
+                    }}
                   />
+                </div>
+                <div className="queue-header">
+                  <span>{files.length ? `${files.length} selected` : "No resumes selected"}</span>
+                  <button className="queue-clear-button" type="button" onClick={clearFiles} disabled={!files.length || isUploading}>
+                    <Trash2 aria-hidden="true" />
+                    Clear all
+                  </button>
                 </div>
                 <ul className="file-list">
                   {files.map((file) => (
-                    <li key={`${file.name}-${file.size}`}>
+                    <li key={fileKey(file)}>
                       <CheckCircle2 aria-hidden="true" />
                       <span>{file.name}</span>
                       <small>{Math.round(file.size / 1024)} KB</small>
+                      <button
+                        className="queue-icon-button"
+                        type="button"
+                        onClick={() => removeFile(file)}
+                        disabled={isUploading}
+                        aria-label={`Remove ${file.name}`}
+                        title={`Remove ${file.name}`}
+                      >
+                        <X aria-hidden="true" />
+                      </button>
                     </li>
                   ))}
                 </ul>
@@ -244,7 +300,7 @@ export default function Dashboard({ user }: { user: SessionUser }) {
                     {failure.fileName}: {failure.error}
                   </p>
                 ))}
-                <button className="run-button" onClick={uploadResumes} disabled={isUploading}>
+                <button className="run-button" onClick={uploadResumes} disabled={isUploading || !files.length}>
                   <SlidersHorizontal aria-hidden="true" />
                   {isUploading ? "Processing resumes..." : "Run SkillMatch Analysis"}
                 </button>

--- a/app/globals.css
+++ b/app/globals.css
@@ -279,20 +279,83 @@ input {
 .file-list {
   display: grid;
   gap: 8px;
-  margin: 14px 0;
+  margin: 8px 0 14px;
+}
+
+.queue-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 34px;
+  margin-top: 12px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.queue-clear-button,
+.queue-icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  background: white;
+  color: #4f5a52;
+}
+
+.queue-clear-button {
+  gap: 6px;
+  min-height: 30px;
+  border-radius: 999px;
+  padding: 0 10px;
+  font-size: 12px;
+  font-weight: 900;
+}
+
+.queue-clear-button svg {
+  width: 14px;
+  height: 14px;
+}
+
+.queue-icon-button {
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+}
+
+.queue-icon-button svg {
+  width: 15px;
+  height: 15px;
+}
+
+.queue-clear-button:disabled,
+.queue-icon-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
 }
 
 .file-list li {
   display: grid;
-  grid-template-columns: 18px 1fr auto;
+  grid-template-columns: 18px minmax(0, 1fr) auto 28px;
   align-items: center;
   gap: 8px;
   color: #414c43;
   font-size: 13px;
 }
 
+.file-list span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .file-list svg {
   color: var(--green);
+}
+
+.file-list .queue-icon-button svg {
+  color: currentColor;
 }
 
 .file-list small,
@@ -328,7 +391,7 @@ input {
 
 .run-button:disabled,
 .primary-action:disabled {
-  cursor: wait;
+  cursor: not-allowed;
   opacity: 0.65;
 }
 

--- a/tests/e2e/skillmatch.spec.ts
+++ b/tests/e2e/skillmatch.spec.ts
@@ -5,6 +5,7 @@ import PDFDocument from "pdfkit";
 
 const fixtureDir = path.join(process.cwd(), "tests", "fixtures");
 const resumePath = path.join(fixtureDir, "alex-smith-sde-resume.pdf");
+const shortResumePath = path.join(fixtureDir, "empty-resume.txt");
 
 function createResumePdf() {
   fs.mkdirSync(fixtureDir, { recursive: true });
@@ -18,7 +19,12 @@ function createResumePdf() {
 }
 
 test.beforeAll(() => {
-  createResumePdf();
+  if (!fs.existsSync(resumePath)) {
+    createResumePdf();
+  }
+  if (!fs.existsSync(shortResumePath)) {
+    fs.writeFileSync(shortResumePath, "Too short.");
+  }
 });
 
 test("requires SSO, uploads a PDF resume, and ranks positions", async ({ page }) => {
@@ -32,11 +38,39 @@ test("requires SSO, uploads a PDF resume, and ranks positions", async ({ page })
   await expect(page.getByRole("heading", { name: "SkillMatch AI" })).toBeVisible();
 
   await page.getByLabel("Upload resume files").setInputFiles(resumePath);
+  await page.getByLabel("Upload resume files").setInputFiles(resumePath);
   await expect(page.getByText("alex-smith-sde-resume.pdf")).toBeVisible();
+  await expect(page.getByText("alex-smith-sde-resume.pdf")).toHaveCount(1);
+
+  await page.getByRole("button", { name: /remove alex-smith-sde-resume\.pdf/i }).click();
+  await expect(page.getByRole("button", { name: /run skillmatch analysis/i })).toBeDisabled();
+
+  await page.getByLabel("Upload resume files").setInputFiles(resumePath);
+  await expect(page.getByRole("button", { name: /run skillmatch analysis/i })).toBeEnabled();
 
   await page.getByRole("button", { name: /run skillmatch analysis/i }).click();
   await expect(page.getByText(/Processed 1 resume/)).toBeVisible();
+  await expect(page.getByRole("button", { name: /run skillmatch analysis/i })).toBeDisabled();
   await expect(page.getByRole("button", { name: /Alex Smith Software/ })).toBeVisible();
   await expect(page.getByText("Software Development Engineer II").nth(1)).toBeVisible();
   await expect(page.getByText("Recommended Positions")).toBeVisible();
+});
+
+test("keeps failed upload state visible after processing", async ({ page }) => {
+  await page.context().clearCookies();
+  await page.goto("/");
+  await expect(page).toHaveURL(/\/login$/);
+
+  await page.getByLabel("Email").fill("recruiter@skillmatch.demo");
+  await page.getByLabel("Password").fill("SkillMatchDemo!23");
+  await page.getByRole("button", { name: /^sign in$/i }).click();
+  await expect(page.getByRole("heading", { name: "SkillMatch AI" })).toBeVisible();
+  await expect(page.getByRole("button", { name: /run skillmatch analysis/i })).toBeDisabled();
+
+  await page.getByLabel("Upload resume files").setInputFiles(shortResumePath);
+  await page.getByRole("button", { name: /run skillmatch analysis/i }).click();
+
+  await expect(page.getByText("No resumes were processed.")).toBeVisible();
+  await expect(page.getByText(/empty-resume\.txt: Resume text could not be extracted\./)).toBeVisible();
+  await expect(page.getByRole("button", { name: /run skillmatch analysis/i })).toBeDisabled();
 });

--- a/tests/fixtures/empty-resume.txt
+++ b/tests/fixtures/empty-resume.txt
@@ -1,0 +1,1 @@
+Too short.


### PR DESCRIPTION
## What changed
- De-duplicates selected resume files in the dashboard upload queue.
- Added per-file remove and clear-all controls.
- Disabled the Run SkillMatch Analysis button until files are queued.
- Kept success/error/partial-failure messages visible after processing.
- Added E2E coverage for duplicate prevention, removal, disabled states, and failed upload messaging.

## Why
- The dashboard should make upload queue state explicit and prevent empty or accidental duplicate submissions before relying on API validation.

## How tested
- `npm run lint` (passes with one existing warning in `app/api/auth/login/route.ts`)
- `npm test`
- `npm run test:e2e -- tests/e2e/skillmatch.spec.ts`

Closes #15