### PR TITLE
Fix preview login session secret fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 DATABASE_URL="postgresql://USER:PASSWORD@HOST.neon.tech/neondb?sslmode=require"
 NEXT_PUBLIC_APP_NAME="SkillMatch AI"
 AUTH_SECRET="replace-with-a-long-random-secret"
+# Optional compatibility fallback when Vercel already provides this secret name.
+BETTER_AUTH_SECRET=""
 AUTH_USERS_JSON='[{"name":"Demo Recruiter","email":"recruiter@skillmatch.demo","role":"recruiter","password":"SkillMatchDemo!23"},{"name":"Demo Admin","email":"admin@skillmatch.demo","role":"system_admin","password":"SkillMatchAdmin!23"},{"name":"Demo Learning","email":"learning@skillmatch.demo","role":"learning_development","password":"SkillMatchLearn!23"}]'
 
 # Optional Cloudflare R2 / S3-compatible resume object storage.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The available variables are listed in `.env.example`.
 | `DATABASE_URL` | Optional for local development; required for persistent database storage | Neon/Postgres connection string used by `lib/db.ts`. When absent, analyses, candidate recommendations, and audit events are kept in process memory. |
 | `NEXT_PUBLIC_APP_NAME` | Optional | Public application name displayed by the app. |
 | `AUTH_SECRET` | Recommended | Secret used to sign the session cookie. If absent, the app uses a local demo secret from `lib/auth.ts`; set a long random value outside local demos. |
+| `BETTER_AUTH_SECRET` | Optional | Compatibility fallback for signing the session cookie when `AUTH_SECRET` is not set. |
 | `AUTH_USERS_JSON` | Optional | JSON array of credential users. Each user needs `name`, `email`, `role`, and either `password` or `passwordHash`. When absent, demo credential users from `lib/auth-model.ts` are used. |
 | `R2_ACCOUNT_ID` | Optional | Cloudflare account ID for R2/S3-compatible resume storage. |
 | `R2_ACCESS_KEY_ID` | Optional | R2 access key ID. |

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -16,26 +16,31 @@ async function appendLoginAuditEvent(input: {
 }
 
 export async function POST(request: Request) {
-  const body = await request.json();
-  const email = String(body.email ?? "");
-  const password = String(body.password ?? "");
-  const user = await verifyCredentials(email, password);
+  try {
+    const body = await request.json();
+    const email = String(body.email ?? "");
+    const password = String(body.password ?? "");
+    const user = await verifyCredentials(email, password);
 
-  if (!user) {
+    if (!user) {
+      await appendLoginAuditEvent({
+        actor: email || "anonymous",
+        action: "failed_login",
+        details: { reason: "invalid_credentials" }
+      });
+      return NextResponse.json({ error: "Invalid email or password." }, { status: 401 });
+    }
+
+    await setSessionUser(user);
     await appendLoginAuditEvent({
-      actor: email || "anonymous",
-      action: "failed_login",
-      details: { reason: "invalid_credentials" }
+      actor: user.email,
+      action: "login",
+      details: { role: user.role }
     });
-    return NextResponse.json({ error: "Invalid email or password." }, { status: 401 });
+
+    return NextResponse.json({ user });
+  } catch (error) {
+    console.error("Unable to complete login", error);
+    return NextResponse.json({ error: "Sign in is temporarily unavailable." }, { status: 500 });
   }
-
-  await setSessionUser(user);
-  await appendLoginAuditEvent({
-    actor: user.email,
-    action: "login",
-    details: { role: user.role }
-  });
-
-  return NextResponse.json({ user });
 }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -12,7 +12,7 @@ type SignedSessionPayload = SessionUser & {
 };
 
 function secret() {
-  const configuredSecret = process.env.AUTH_SECRET?.trim();
+  const configuredSecret = process.env.AUTH_SECRET?.trim() || process.env.BETTER_AUTH_SECRET?.trim();
 
   if (configuredSecret) {
     if (!allowsLocalDemoSecret() && !isStrongSecret(configuredSecret)) {
@@ -23,7 +23,7 @@ function secret() {
   }
 
   if (!allowsLocalDemoSecret()) {
-    throw new Error("AUTH_SECRET must be set to a strong random value in production.");
+    throw new Error("AUTH_SECRET or BETTER_AUTH_SECRET must be set to a strong random value in production.");
   }
 
   return localDemoSecret;

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -9,6 +9,7 @@ const admin: SessionUser = {
 };
 
 const originalAuthSecret = process.env.AUTH_SECRET;
+const originalBetterAuthSecret = process.env.BETTER_AUTH_SECRET;
 const originalNodeEnv = process.env.NODE_ENV;
 
 function setNodeEnv(value: typeof process.env.NODE_ENV) {
@@ -22,6 +23,7 @@ function setNodeEnv(value: typeof process.env.NODE_ENV) {
 
 beforeEach(() => {
   delete process.env.AUTH_SECRET;
+  delete process.env.BETTER_AUTH_SECRET;
   setNodeEnv("test");
   vi.useRealTimers();
 });
@@ -31,6 +33,12 @@ afterEach(() => {
     delete process.env.AUTH_SECRET;
   } else {
     process.env.AUTH_SECRET = originalAuthSecret;
+  }
+
+  if (originalBetterAuthSecret === undefined) {
+    delete process.env.BETTER_AUTH_SECRET;
+  } else {
+    process.env.BETTER_AUTH_SECRET = originalBetterAuthSecret;
   }
 
   setNodeEnv(originalNodeEnv);
@@ -74,11 +82,11 @@ describe("auth and RBAC", () => {
     expect(parseSessionToken(`${token}tampered`)).toBeNull();
   });
 
-  it("requires AUTH_SECRET in production", () => {
+  it("requires a session secret in production", () => {
     setNodeEnv("production");
     delete process.env.AUTH_SECRET;
 
-    expect(() => createSessionToken(admin)).toThrow(/AUTH_SECRET must be set/);
+    expect(() => createSessionToken(admin)).toThrow(/AUTH_SECRET or BETTER_AUTH_SECRET must be set/);
   });
 
   it("rejects weak AUTH_SECRET values in production", () => {
@@ -86,6 +94,15 @@ describe("auth and RBAC", () => {
     process.env.AUTH_SECRET = "short-secret";
 
     expect(() => createSessionToken(admin)).toThrow(/AUTH_SECRET must be a strong random value/);
+  });
+
+  it("accepts BETTER_AUTH_SECRET as the production session secret", () => {
+    setNodeEnv("production");
+    process.env.BETTER_AUTH_SECRET = "a-production-secret-with-enough-entropy-12345";
+
+    const token = createSessionToken(admin);
+
+    expect(parseSessionToken(token)).toEqual(admin);
   });
 
   it("enforces role-based access for admin and recruiter areas", () => {


### PR DESCRIPTION
## What changed

- Read `BETTER_AUTH_SECRET` as a fallback session signing secret when `AUTH_SECRET` is not set.
- Return a JSON login failure instead of surfacing a full page crash when login setup fails.
- Document the fallback env var and add a production-mode unit test for it.

## Why

The failing Vercel Preview deployment had `BETTER_AUTH_SECRET` configured, but the app only read `AUTH_SECRET`. Login succeeded through the database lookup, then failed while signing the session cookie with `AUTH_SECRET must be set to a strong random value in production.`

## Tested

- `npm test`
- `npm run lint`
- `npm run build`