### PR TITLE
[codex] Add documentation maintenance process

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+
+- What changed?
+- Why was it needed?
+
+## Testing
+
+- [ ] Not run
+- [ ] `npm run lint`
+- [ ] `npm test`
+- [ ] `npm run build`
+- [ ] `npm run test:e2e`
+- [ ] Other (describe below)
+
+## Documentation Review
+
+- [ ] I checked whether this change affects `README.md`, `docs/**`, or other implementation documentation.
+- [ ] If documentation changed, I updated the relevant files in this PR.
+- [ ] If repo-facing implementation details changed, I added or updated an entry in `docs/implementation-change-log.md`.
+
+## Notes
+
+- Additional context, rollout details, or follow-ups.

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,4 @@ coverage
 .env.local
 npm-debug.log*
 .vercel
-docs
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -97,3 +97,11 @@ npm run test:e2e
 `npm run test:e2e` starts the app with Playwright's configured web server at `http://127.0.0.1:3000/login` and runs the Chromium end-to-end tests from `tests/e2e`.
 
 The GitHub Actions workflow in `.github/workflows/ci.yml` runs on pull requests and pushes to `main`. It uses Node.js 22, installs dependencies with `npm ci`, installs the Playwright Chromium browser, then runs lint, unit tests, build, and Playwright end-to-end tests.
+
+## Documentation Maintenance
+
+Documentation updates belong in the same change as the code update.
+
+- Use `docs/documentation-process.md` when a change affects setup, architecture, behavior, operational expectations, or developer workflows.
+- Add a short dated entry to `docs/implementation-change-log.md` whenever repo-facing implementation details change.
+- The PR checklist in `.github/PULL_REQUEST_TEMPLATE.md` is the review backstop for this process.

--- a/docs/documentation-process.md
+++ b/docs/documentation-process.md
@@ -1,0 +1,41 @@
+# Documentation Update Process
+
+Keep documentation changes in the same pull request as the software change whenever possible.
+
+## When To Update Docs
+
+Update repo documentation if a change affects any of these:
+
+- Local setup or environment configuration
+- User-visible behavior or workflow expectations
+- Database, storage, auth, or integration design
+- Developer workflows, testing steps, or operational runbooks
+
+## What To Update
+
+Use the smallest set of files that keeps the repo accurate:
+
+- `README.md` for setup, architecture summary, environment variables, and common commands
+- `docs/` files for implementation details, process notes, or longer-lived reference material
+- `docs/implementation-change-log.md` for a short dated note about meaningful documentation-impacting changes
+
+## Change Log Format
+
+Add one entry per relevant change using this format:
+
+```md
+## YYYY-MM-DD
+
+- Short note describing the software change and which documentation was updated.
+```
+
+Keep entries brief. The goal is traceability, not a full release history.
+
+## Pull Request Expectation
+
+Before opening a PR:
+
+1. Check whether the code change affects documented behavior or implementation details.
+2. Update the relevant `README.md` or `docs/**` files in the same branch.
+3. Add or update the dated note in `docs/implementation-change-log.md` if the change altered repo-facing implementation details.
+4. Complete the PR checklist item confirming the documentation review.

--- a/docs/implementation-change-log.md
+++ b/docs/implementation-change-log.md
@@ -1,0 +1,7 @@
+# Implementation Change Log
+
+This file records short dated notes for changes that should stay reflected in `README.md` or `docs/**`.
+
+## 2026-05-02
+
+- Added a lightweight documentation maintenance process, a repo-native implementation change log, and a PR checklist to keep SED and implementation docs in sync with code changes.


### PR DESCRIPTION
## What changed
- removed `docs` from `.gitignore`
- added an in-repo documentation maintenance guide and implementation change log
- added a pull request template with documentation review checks
- linked the process from `README.md`

## Why it changed
Issue #48 calls for a lightweight way to keep implementation and SED-adjacent documentation current as the software evolves. The repo did not previously track docs or enforce documentation review in PRs.

## How it was tested
- Documentation-only change; no runtime tests were run in this environment
- Verified the new docs and PR template paths are present in the repo content updates

Closes #48