### PR TITLE
Clarify credential-based auth wording

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -37,7 +37,7 @@ export default function LoginPage() {
           <span>SkillMatch AI</span>
         </div>
         <h1>Secure sign in</h1>
-        <p>Use the demo credentials configured for this environment.</p>
+        <p>Sign in with the demo email and password configured for this environment.</p>
 
         <label>
           Email

--- a/tests/e2e/skillmatch.spec.ts
+++ b/tests/e2e/skillmatch.spec.ts
@@ -36,7 +36,7 @@ test("allows signed-out users to open signup", async ({ page }) => {
   await expect(page.getByRole("button", { name: "Create account" })).toBeVisible();
 });
 
-test("requires SSO, uploads a PDF resume, and ranks positions", async ({ page }) => {
+test("requires credential sign-in, uploads a PDF resume, and ranks positions", async ({ page }) => {
   await page.context().clearCookies();
   await page.goto("/");
   await expect(page).toHaveURL(/\/login$/);


### PR DESCRIPTION
## What changed
- updated the login helper copy to explicitly describe demo email/password sign-in
- renamed the end-to-end auth smoke test so it no longer claims SSO

## Why it changed
Issue #30 asks the repo to stop overclaiming SSO when the current MVP uses credential-based authentication.

## How it was tested
- reviewed the branch diff for the copy-only auth wording change
- automated lint and Playwright runs were not possible in this sandbox because dependencies are not installed locally

Closes #30