### PR TITLE
Add opt-in cross-browser Playwright coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,4 +96,26 @@ npm run test:e2e
 
 `npm run test:e2e` starts the app with Playwright's configured web server at `http://127.0.0.1:3000/login` and runs the Chromium end-to-end tests from `tests/e2e`.
 
+For browser-matrix work on issue #40, the Playwright config also supports opt-in Chrome, Edge, and Safari-like WebKit coverage:
+
+```powershell
+$env:PLAYWRIGHT_CROSS_BROWSER="1"
+npx playwright install webkit
+npm run test:e2e
+```
+
+You can also target a subset of projects:
+
+```powershell
+$env:PLAYWRIGHT_PROJECTS="webkit"
+npx playwright install webkit
+npm run test:e2e
+```
+
+Browser limitations:
+
+- The default `npm run test:e2e` flow stays on the Playwright-managed Chromium project so the existing local and CI checks do not change implicitly.
+- The `chrome` and `edge` projects use Playwright browser channels (`channel: "chrome"` and `channel: "msedge"`), so they require locally installed Chrome or Edge.
+- The `webkit` project uses Playwright's WebKit browser for Safari-like coverage and requires `npx playwright install webkit` before first use.
+
 The GitHub Actions workflow in `.github/workflows/ci.yml` runs on pull requests and pushes to `main`. It uses Node.js 22, installs dependencies with `npm ci`, installs the Playwright Chromium browser, then runs lint, unit tests, build, and Playwright end-to-end tests.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,47 @@
-import { defineConfig, devices } from "@playwright/test";
+import { defineConfig, devices, type PlaywrightTestConfig } from "@playwright/test";
+
+type Project = NonNullable<PlaywrightTestConfig["projects"]>[number];
+
+const defaultProjects: Project[] = [
+  {
+    name: "chromium",
+    use: { ...devices["Desktop Chrome"] }
+  }
+];
+
+const crossBrowserProjects: Project[] = [
+  {
+    name: "chrome",
+    use: { ...devices["Desktop Chrome"], channel: "chrome" }
+  },
+  {
+    name: "edge",
+    use: { ...devices["Desktop Edge"], channel: "msedge" }
+  },
+  {
+    name: "webkit",
+    use: { ...devices["Desktop Safari"] }
+  }
+];
+
+function getProjects(): Project[] {
+  const requestedProjects = (process.env.PLAYWRIGHT_PROJECTS ?? "")
+    .split(",")
+    .map((project) => project.trim())
+    .filter(Boolean);
+
+  const availableProjects = [...defaultProjects, ...crossBrowserProjects];
+
+  if (requestedProjects.length > 0) {
+    return availableProjects.filter((project) => requestedProjects.includes(project.name));
+  }
+
+  if (process.env.PLAYWRIGHT_CROSS_BROWSER === "1") {
+    return availableProjects;
+  }
+
+  return defaultProjects;
+}
 
 export default defineConfig({
   testDir: "./tests/e2e",
@@ -16,10 +59,5 @@ export default defineConfig({
     reuseExistingServer: false,
     timeout: 30_000
   },
-  projects: [
-    {
-      name: "chromium",
-      use: { ...devices["Desktop Chrome"] }
-    }
-  ]
+  projects: getProjects()
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,10 @@ import { defineConfig, devices, type PlaywrightTestConfig } from "@playwright/te
 
 type Project = NonNullable<PlaywrightTestConfig["projects"]>[number];
 
+const edgeChannel =
+  process.env.PLAYWRIGHT_EDGE_CHANNEL ??
+  (process.platform === "win32" ? "msedge" : undefined);
+
 const defaultProjects: Project[] = [
   {
     name: "chromium",
@@ -35,7 +39,7 @@ function getProjects(): Project[] {
   const availableProjects = [...defaultProjects, ...crossBrowserProjects];
 
   if (requestedProjects.length > 0) {
-    return availableProjects.filter((project) => requestedProjects.includes(project.name));
+    return availableProjects.filter((project) => Boolean(project.name && requestedProjects.includes(project.name)));
   }
 
   if (process.env.PLAYWRIGHT_CROSS_BROWSER === "1") {
@@ -44,10 +48,6 @@ function getProjects(): Project[] {
 
   return defaultProjects;
 }
-
-const edgeChannel =
-  process.env.PLAYWRIGHT_EDGE_CHANNEL ??
-  (process.platform === "win32" ? "msedge" : undefined);
 
 export default defineConfig({
   testDir: "./tests/e2e",

--- a/tests/e2e/skillmatch.spec.ts
+++ b/tests/e2e/skillmatch.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 import fs from "node:fs";
 import path from "node:path";
 import PDFDocument from "pdfkit";
@@ -27,6 +27,16 @@ test.beforeAll(() => {
   }
 });
 
+async function signInAsDemoRecruiter(page: Page) {
+  await page.goto("/");
+  await expect(page).toHaveURL(/\/login$/);
+
+  await page.getByLabel("Email").fill("recruiter@skillmatch.demo");
+  await page.getByLabel("Password").fill("SkillMatchDemo!23");
+  await page.getByRole("button", { name: /^sign in$/i }).click();
+  await expect(page.getByRole("heading", { name: "SkillMatch AI" })).toBeVisible();
+}
+
 test("allows signed-out users to open signup", async ({ page }) => {
   await page.context().clearCookies();
   await page.goto("/signup");
@@ -38,13 +48,7 @@ test("allows signed-out users to open signup", async ({ page }) => {
 
 test("requires SSO, uploads a PDF resume, and ranks positions", async ({ page }) => {
   await page.context().clearCookies();
-  await page.goto("/");
-  await expect(page).toHaveURL(/\/login$/);
-
-  await page.getByLabel("Email").fill("recruiter@skillmatch.demo");
-  await page.getByLabel("Password").fill("SkillMatchDemo!23");
-  await page.getByRole("button", { name: /^sign in$/i }).click();
-  await expect(page.getByRole("heading", { name: "SkillMatch AI" })).toBeVisible();
+  await signInAsDemoRecruiter(page);
 
   await page.getByLabel("Upload resume files").setInputFiles(resumePath);
   await page.getByLabel("Upload resume files").setInputFiles(resumePath);
@@ -67,13 +71,7 @@ test("requires SSO, uploads a PDF resume, and ranks positions", async ({ page })
 
 test("keeps failed upload state visible after processing", async ({ page }) => {
   await page.context().clearCookies();
-  await page.goto("/");
-  await expect(page).toHaveURL(/\/login$/);
-
-  await page.getByLabel("Email").fill("recruiter@skillmatch.demo");
-  await page.getByLabel("Password").fill("SkillMatchDemo!23");
-  await page.getByRole("button", { name: /^sign in$/i }).click();
-  await expect(page.getByRole("heading", { name: "SkillMatch AI" })).toBeVisible();
+  await signInAsDemoRecruiter(page);
   await expect(page.getByRole("button", { name: /run skillmatch analysis/i })).toBeDisabled();
 
   await page.getByLabel("Upload resume files").setInputFiles(shortResumePath);


### PR DESCRIPTION
## What changed
- added opt-in Playwright projects for Chrome, Edge, and WebKit while keeping Chromium as the default run
- refactored the shared demo sign-in step in the E2E suite
- documented the browser matrix commands and channel limitations in the README

## Why it changed
Issue #40 asks for cross-browser validation coverage without destabilizing the existing default local and CI flow.

## How it was tested
- reviewed the Playwright config and E2E diff for project selection behavior
- automated Playwright execution was not possible in this sandbox because dependencies and browser installs are unavailable locally

Closes #40