### PR TITLE
Add repo-owned documentation maintenance workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+- Describe what changed.
+- Describe why the change was needed.
+
+## Testing
+
+- List the checks you ran.
+- Note any checks you could not run.
+
+## Documentation
+
+- [ ] I updated `README.md` or `docs/*` when behavior, architecture, testing, or deployment expectations changed.
+- [ ] I added or skipped a `docs/changelog.md` entry with a short reason.
+- [ ] I organized any source Office docs under `docs/source/` and any committed exports under `docs/generated/`.

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,4 @@ coverage
 .env.local
 npm-debug.log*
 .vercel
-docs
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -97,3 +97,14 @@ npm run test:e2e
 `npm run test:e2e` starts the app with Playwright's configured web server at `http://127.0.0.1:3000/login` and runs the Chromium end-to-end tests from `tests/e2e`.
 
 The GitHub Actions workflow in `.github/workflows/ci.yml` runs on pull requests and pushes to `main`. It uses Node.js 22, installs dependencies with `npm ci`, installs the Playwright Chromium browser, then runs lint, unit tests, build, and Playwright end-to-end tests.
+
+## Documentation Maintenance
+
+Project documentation now lives in the repo under `docs/` so process notes can evolve with the codebase:
+
+- `docs/README.md` explains the lightweight documentation workflow and when updates are expected.
+- `docs/changelog.md` records architecture, requirements, testing, and deployment-facing changes over time.
+- `docs/source/` is for editable source artifacts such as `.docx`, slide decks, and working notes when they should be versioned with the repo.
+- `docs/generated/` is for exported artifacts such as PDFs or presentation renders when they are needed for review or submission.
+
+When a pull request changes user-facing behavior, architecture, environment requirements, testing strategy, or deployment steps, update the relevant docs in the same branch and note the change in `docs/changelog.md`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,37 @@
+# Documentation Workflow
+
+This repository keeps lightweight, living documentation close to the implementation so software changes and process changes can be reviewed together.
+
+## What Goes Here
+
+- `changelog.md`: short entries for architecture, requirements, testing, deployment, and workflow changes.
+- `source/`: editable source artifacts such as `.docx`, slide decks, and draft source material that should be versioned with the repo.
+- `generated/`: exported artifacts such as PDFs, submission exports, and presentation renders that are worth preserving.
+
+## Working Rule
+
+Use Markdown in this repo for ongoing maintenance notes and process documentation. Keep Office artifacts only when they are the actual source of record for a class deliverable, external review, or shared handoff.
+
+That means:
+
+- convert living process notes into Markdown when they need frequent updates
+- store `.docx` or slide sources in `docs/source/` when the original format matters
+- store generated PDFs or exports in `docs/generated/` only when they are needed for review, submission, or traceability
+- avoid scattering documentation across personal folders once it becomes relevant to the repo
+
+## When To Update Docs
+
+Update docs in the same pull request when work changes:
+
+- user-facing behavior or product scope
+- architecture, data flow, or storage decisions
+- authentication, environment, or deployment requirements
+- test coverage expectations or QA steps
+- operating procedures that another contributor would need to follow
+
+## Minimum Update Process
+
+1. Make the code or workflow change.
+2. Update the relevant Markdown or source artifact in `docs/`.
+3. Add a concise entry to `docs/changelog.md`.
+4. Check the PR checklist before requesting review.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,12 @@
+# Documentation Changelog
+
+Use this file to keep a lightweight trail of documentation-impacting changes. Keep entries short and focused on what changed, why it matters, and where follow-up docs live.
+
+## Entry Format
+
+| Date | Area | Change | Related Files |
+| --- | --- | --- | --- |
+
+## Entries
+
+| 2026-05-02 | Docs process | Added repo-owned documentation workflow, changelog guidance, PR checklist prompts, and artifact organization rules for source vs generated docs. | `README.md`, `docs/README.md`, `docs/source/README.md`, `docs/generated/README.md`, `.github/pull_request_template.md` |

--- a/docs/generated/README.md
+++ b/docs/generated/README.md
@@ -1,0 +1,11 @@
+# Generated Artifacts
+
+Store generated documentation outputs here when they should travel with the repository.
+
+Examples:
+
+- exported PDFs
+- rendered slide decks
+- packaged submission copies
+
+Do not add generated files by default. Commit them only when they are needed for review, grading, release traceability, or a handoff that depends on the exact exported output.

--- a/docs/source/README.md
+++ b/docs/source/README.md
@@ -1,0 +1,12 @@
+# Source Artifacts
+
+Store editable documentation source files here when the original format matters.
+
+Examples:
+
+- software engineering document `.docx` files
+- slide decks
+- diagrams with editable source data
+- instructor-facing deliverables that should stay in their original format
+
+Prefer filenames that include the artifact name and term or milestone. If a document also has a generated PDF or export, keep that output in `../generated/`.


### PR DESCRIPTION
## What changed
- added a lightweight `docs/` maintenance workflow and changelog guidance
- added source vs generated artifact organization notes
- added a pull request checklist for documentation updates
- updated the README to point contributors at the new process

## Why it changed
Issue #48 asks for the implementation and process documentation to live with the code and stay current as the product changes.

## How it was tested
- reviewed the new docs structure and checklist content for consistency
- `git diff --check` passed in the local workspace for the docs/process files

Closes #48