### PR TITLE
Fix issue #19 demographic masking regressions

### DIFF
--- a/lib/skillmatch.ts
+++ b/lib/skillmatch.ts
@@ -88,6 +88,23 @@ const certificationPatterns = [
   /scrum master/gi
 ];
 
+const demographicMaskingRules: Array<[RegExp, string]> = [
+  [/^[A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,2}\s*$/gm, "[name masked]"],
+  [/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[email masked]"],
+  [/\b(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b/g, "[phone masked]"],
+  [
+    /\b(?:age|dob|date of birth)\s*[:\-]?\s*(?:\d{1,3}|\d{1,2}\/\d{1,2}\/\d{2,4}|[A-Za-z]+\s+\d{1,2},?\s+\d{4})\b/gi,
+    "[age masked]"
+  ],
+  [/\b\d{1,3}\s*(?:years old|yrs old|y\/o)\b/gi, "[age masked]"],
+  [/\b(?:gender|sex)\s*[:\-]?\s*(?:female|male|woman|man|non[-\s]?binary|trans(?:gender)?|prefer not to say)\b/gi, "[gender masked]"],
+  [/\bpronouns?\s*[:\-]?\s*[a-z]+\/[a-z]+\b/gi, "[pronouns masked]"],
+  [
+    /\b(?:race|ethnicity|nationality|citizenship|marital status|veteran status|disability status|religion)\s*[:\-]?\s*[^\r\n,;]+/gi,
+    "[demographic masked]"
+  ]
+];
+
 export function normalizeResumeText(text: string) {
   return text
     .toLowerCase()
@@ -122,11 +139,10 @@ function findEvidenceSnippet(resumeText: string, terms: string[]) {
 }
 
 export function maskDemographicSignals(text: string) {
-  return text
-    .replace(/^[A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,2}\s*$/gm, "[name masked]")
-    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[email masked]")
-    .replace(/\b(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b/g, "[phone masked]")
-    .replace(/\b(?:age|dob|date of birth)\s*[:\-]?\s*\d{1,2}\/\d{1,2}\/\d{2,4}\b/gi, "[age masked]");
+  return demographicMaskingRules.reduce(
+    (maskedText, [pattern, replacement]) => maskedText.replace(pattern, replacement),
+    text
+  );
 }
 
 export function extractSkills(resumeText: string) {

--- a/tests/skillmatch.test.ts
+++ b/tests/skillmatch.test.ts
@@ -99,4 +99,58 @@ describe("skill matching engine", () => {
     expect(analysis.structured.certifications.join(" ")).toMatch(/AWS Certified|Cloud Practitioner/i);
     expect(maskDemographicSignals(analysis.structured.biasMaskedText)).toContain("[email masked]");
   });
+
+  it("masks explicit demographic fields beyond contact details", () => {
+    const masked = maskDemographicSignals(
+      [
+        "Jamie Doe",
+        "jamie@example.com",
+        "312-555-0199",
+        "Gender: Female",
+        "Pronouns: she/her",
+        "Race: Asian",
+        "Nationality: Canadian",
+        "Age: 29",
+        "Veteran Status: Protected Veteran"
+      ].join("\n")
+    );
+
+    expect(masked).toContain("[name masked]");
+    expect(masked).toContain("[email masked]");
+    expect(masked).toContain("[phone masked]");
+    expect(masked).toContain("[gender masked]");
+    expect(masked).toContain("[pronouns masked]");
+    expect(masked).toContain("[demographic masked]");
+    expect(masked).toContain("[age masked]");
+    expect(masked).not.toMatch(/\bFemale|Asian|Canadian|29|Protected Veteran|she\/her\b/);
+  });
+
+  it("keeps scoring stable across equivalent resumes with different demographic details", () => {
+    const sharedExperience =
+      "Backend engineer with 6 years experience building TypeScript, React, Node, SQL, Git, AWS, CI/CD, and REST API systems.";
+    const resumeA = [
+      "Jordan Lee",
+      "Gender: Female",
+      "Pronouns: she/her",
+      "Race: Asian",
+      "Age: 29",
+      sharedExperience
+    ].join("\n");
+    const resumeB = [
+      "Jordan Lee",
+      "Gender: Male",
+      "Pronouns: he/him",
+      "Race: Black",
+      "Age: 46",
+      sharedExperience
+    ].join("\n");
+
+    const resultA = analyzeResume(resumeA, "sde-ii");
+    const resultB = analyzeResume(resumeB, "sde-ii");
+
+    expect(resultA.score).toBe(resultB.score);
+    expect(resultA.matchedSkills).toEqual(resultB.matchedSkills);
+    expect(resultA.missingSkills).toEqual(resultB.missingSkills);
+    expect(resultA.explanationDetails.earnedWeight).toBe(resultB.explanationDetails.earnedWeight);
+  });
 });


### PR DESCRIPTION
## What changed
- expanded demographic masking to cover more explicit protected-attribute style fields
- added regression coverage for masking and score stability across equivalent resumes

## Why
- addresses issue #19 by reducing demographic leakage risk and guarding fairness-sensitive behavior

## Testing
- automated tests were added but not executed in this sandbox because `node_modules` is unavailable here

Closes #19