### PR TITLE
Add issue #26 runtime environment validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,10 +3,12 @@ NEXT_PUBLIC_APP_NAME="SkillMatch AI"
 AUTH_SECRET="replace-with-a-long-random-secret"
 # Optional compatibility fallback when Vercel already provides this secret name.
 BETTER_AUTH_SECRET=""
+# Required in production to disable demo credential fallback.
 AUTH_USERS_JSON='[{"name":"Demo Recruiter","email":"recruiter@skillmatch.demo","role":"recruiter","password":"SkillMatchDemo!23"},{"name":"Demo Admin","email":"admin@skillmatch.demo","role":"system_admin","password":"SkillMatchAdmin!23"},{"name":"Demo Learning","email":"learning@skillmatch.demo","role":"learning_development","password":"SkillMatchLearn!23"}]'
 
-# Optional Cloudflare R2 / S3-compatible resume object storage.
-# Without these values, local development uses an in-memory storage URL.
+# Database storage is optional in local development and required in production.
+# Cloudflare R2 / S3-compatible resume object storage is also optional locally.
+# Without the full R2 set below, local development uses an in-memory storage URL.
 R2_ACCOUNT_ID=""
 R2_ACCESS_KEY_ID=""
 R2_SECRET_ACCESS_KEY=""

--- a/lib/auth-model.ts
+++ b/lib/auth-model.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import { eq } from "drizzle-orm";
 import { users } from "@/db/schema";
 import { getDatabase } from "./database";
+import { getAuthConfig } from "./env";
 import { sessionUserSchema, signupRequestSchema, userRoleSchema, type UserRole } from "./validation";
 
 export type SessionUser = {
@@ -53,7 +54,7 @@ function verifyPasswordHash(password: string, passwordHash: string) {
 }
 
 export function getCredentialUsers() {
-  const configuredUsers = process.env.AUTH_USERS_JSON;
+  const configuredUsers = getAuthConfig(process.env, { requireUsers: true }).usersJson;
   if (!configuredUsers) {
     return fallbackCredentialUsers;
   }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,10 +1,10 @@
 import { cookies } from "next/headers";
 import crypto from "node:crypto";
 import type { SessionUser } from "./auth-model";
+import { getAuthConfig } from "./env";
 import { sessionUserSchema, signedSessionPayloadSchema } from "./validation";
 
 const cookieName = "skillmatch_session";
-const localDemoSecret = "skillmatch-ai-local-demo-secret";
 const sessionMaxAgeSeconds = 60 * 60 * 8;
 
 type SignedSessionPayload = SessionUser & {
@@ -13,37 +13,7 @@ type SignedSessionPayload = SessionUser & {
 };
 
 function secret() {
-  const configuredSecret = process.env.AUTH_SECRET?.trim() || process.env.BETTER_AUTH_SECRET?.trim();
-
-  if (configuredSecret) {
-    if (!allowsLocalDemoSecret() && !isStrongSecret(configuredSecret)) {
-      throw new Error("AUTH_SECRET must be a strong random value of at least 32 characters in production.");
-    }
-
-    return configuredSecret;
-  }
-
-  if (!allowsLocalDemoSecret()) {
-    throw new Error("AUTH_SECRET or BETTER_AUTH_SECRET must be set to a strong random value in production.");
-  }
-
-  return localDemoSecret;
-}
-
-function allowsLocalDemoSecret() {
-  return process.env.NODE_ENV !== "production";
-}
-
-function isStrongSecret(value: string) {
-  const weakSecrets = new Set([
-    localDemoSecret,
-    "replace-with-a-long-random-secret",
-    "changeme",
-    "password",
-    "secret"
-  ]);
-
-  return value.length >= 32 && new Set(value).size >= 8 && !weakSecrets.has(value.toLowerCase());
+  return getAuthConfig(process.env, { requireUsers: false }).secret;
 }
 
 function sign(payload: string) {

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -1,10 +1,13 @@
 import { neon } from "@neondatabase/serverless";
 import { drizzle } from "drizzle-orm/neon-http";
+import { getDatabaseConfig } from "./env";
 
 export function getDatabase() {
-  if (!process.env.DATABASE_URL) {
+  const { url } = getDatabaseConfig();
+
+  if (!url) {
     return null;
   }
 
-  return drizzle(neon(process.env.DATABASE_URL));
+  return drizzle(neon(url));
 }

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,171 @@
+import { sessionUserSchema } from "./validation";
+
+const localDemoSecret = "skillmatch-ai-local-demo-secret";
+
+const weakSecrets = new Set([
+  localDemoSecret,
+  "replace-with-a-long-random-secret",
+  "changeme",
+  "password",
+  "secret"
+]);
+
+type StorageConfig =
+  | {
+      provider: "local";
+    }
+  | {
+      provider: "r2";
+      accountId: string;
+      accessKeyId: string;
+      secretAccessKey: string;
+      bucket: string;
+      publicBaseUrl: string | null;
+    };
+
+function readEnvValue(env: NodeJS.ProcessEnv, key: string) {
+  const value = env[key]?.trim();
+  return value ? value : null;
+}
+
+function isProductionEnvironment(env: NodeJS.ProcessEnv) {
+  return env.NODE_ENV === "production";
+}
+
+function createEnvError(...issues: string[]) {
+  return new Error(`Invalid runtime environment:\n- ${issues.join("\n- ")}`);
+}
+
+function isStrongSecret(value: string) {
+  return value.length >= 32 && new Set(value).size >= 8 && !weakSecrets.has(value.toLowerCase());
+}
+
+function validateCredentialUsersJson(value: string) {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw createEnvError("AUTH_USERS_JSON must be valid JSON.");
+  }
+
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    throw createEnvError("AUTH_USERS_JSON must be a non-empty JSON array.");
+  }
+
+  for (const user of parsed) {
+    const password = typeof user === "object" && user ? (user as Record<string, unknown>).password : undefined;
+    const passwordHash =
+      typeof user === "object" && user ? (user as Record<string, unknown>).passwordHash : undefined;
+    const hasPassword =
+      (typeof password === "string" && password.trim().length > 0) ||
+      (typeof passwordHash === "string" && passwordHash.trim().length > 0);
+
+    if (!sessionUserSchema.safeParse(user).success || !hasPassword) {
+      throw createEnvError(
+        "AUTH_USERS_JSON users must include valid name, email, role, and password or passwordHash values."
+      );
+    }
+  }
+}
+
+export function getAuthConfig(
+  env: NodeJS.ProcessEnv = process.env,
+  options: { requireUsers?: boolean } = {}
+) {
+  const configuredSecret = readEnvValue(env, "AUTH_SECRET") ?? readEnvValue(env, "BETTER_AUTH_SECRET");
+  const usersJson = readEnvValue(env, "AUTH_USERS_JSON");
+  const production = isProductionEnvironment(env);
+  const requireUsers = options.requireUsers ?? true;
+
+  if (configuredSecret && production && !isStrongSecret(configuredSecret)) {
+    throw createEnvError("AUTH_SECRET must be a strong random value of at least 32 characters in production.");
+  }
+
+  if (usersJson) {
+    validateCredentialUsersJson(usersJson);
+  } else if (production && requireUsers) {
+    throw createEnvError("AUTH_USERS_JSON must be configured in production instead of using demo users.");
+  }
+
+  if (configuredSecret) {
+    return {
+      secret: configuredSecret,
+      usersJson,
+      usesLocalDemoSecret: false,
+      usesFallbackUsers: !usersJson
+    };
+  }
+
+  if (production) {
+    throw createEnvError("AUTH_SECRET or BETTER_AUTH_SECRET must be set to a strong random value in production.");
+  }
+
+  return {
+    secret: localDemoSecret,
+    usersJson,
+    usesLocalDemoSecret: true,
+    usesFallbackUsers: !usersJson
+  };
+}
+
+export function getDatabaseConfig(env: NodeJS.ProcessEnv = process.env) {
+  const databaseUrl = readEnvValue(env, "DATABASE_URL");
+
+  if (!databaseUrl && isProductionEnvironment(env)) {
+    throw createEnvError("DATABASE_URL must be configured in production.");
+  }
+
+  return {
+    url: databaseUrl,
+    usesMemoryFallback: !databaseUrl
+  };
+}
+
+export function getStorageConfig(env: NodeJS.ProcessEnv = process.env): StorageConfig {
+  const accountId = readEnvValue(env, "R2_ACCOUNT_ID");
+  const accessKeyId = readEnvValue(env, "R2_ACCESS_KEY_ID");
+  const secretAccessKey = readEnvValue(env, "R2_SECRET_ACCESS_KEY");
+  const bucket = readEnvValue(env, "R2_BUCKET");
+  const publicBaseUrl = readEnvValue(env, "R2_PUBLIC_BASE_URL");
+
+  const requiredEntries = [
+    ["R2_ACCOUNT_ID", accountId],
+    ["R2_ACCESS_KEY_ID", accessKeyId],
+    ["R2_SECRET_ACCESS_KEY", secretAccessKey],
+    ["R2_BUCKET", bucket]
+  ] as const;
+
+  const configuredCount = requiredEntries.filter(([, value]) => value).length;
+  if (configuredCount > 0 && configuredCount < requiredEntries.length) {
+    const missingKeys = requiredEntries.filter(([, value]) => !value).map(([key]) => key);
+    throw createEnvError(`R2 storage configuration is incomplete. Missing: ${missingKeys.join(", ")}.`);
+  }
+
+  if (configuredCount === 0) {
+    if (isProductionEnvironment(env)) {
+      throw createEnvError(
+        "R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, and R2_BUCKET must be configured in production."
+      );
+    }
+
+    return { provider: "local" };
+  }
+
+  return {
+    provider: "r2",
+    accountId: accountId as string,
+    accessKeyId: accessKeyId as string,
+    secretAccessKey: secretAccessKey as string,
+    bucket: bucket as string,
+    publicBaseUrl
+  };
+}
+
+export function validateRuntimeEnvironment(env: NodeJS.ProcessEnv = process.env) {
+  return {
+    auth: getAuthConfig(env, { requireUsers: true }),
+    database: getDatabaseConfig(env),
+    storage: getStorageConfig(env)
+  };
+}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,4 +1,5 @@
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import { getStorageConfig } from "./env";
 
 type StoredObject = {
   key: string;
@@ -9,18 +10,16 @@ type StoredObject = {
 const localObjects = new Map<string, Uint8Array>();
 
 function getR2Client() {
-  const accountId = process.env.R2_ACCOUNT_ID;
-  const accessKeyId = process.env.R2_ACCESS_KEY_ID;
-  const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY;
+  const config = getStorageConfig();
 
-  if (!accountId || !accessKeyId || !secretAccessKey || !process.env.R2_BUCKET) {
+  if (config.provider !== "r2") {
     return null;
   }
 
   return new S3Client({
     region: "auto",
-    endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
-    credentials: { accessKeyId, secretAccessKey }
+    endpoint: `https://${config.accountId}.r2.cloudflarestorage.com`,
+    credentials: { accessKeyId: config.accessKeyId, secretAccessKey: config.secretAccessKey }
   });
 }
 
@@ -37,11 +36,12 @@ export async function storeResumeFile(input: {
     input.fileName
   )}`;
   const client = getR2Client();
+  const storageConfig = getStorageConfig();
 
-  if (client) {
+  if (client && storageConfig.provider === "r2") {
     await client.send(
       new PutObjectCommand({
-        Bucket: process.env.R2_BUCKET,
+        Bucket: storageConfig.bucket,
         Key: key,
         Body: input.bytes,
         ContentType: input.contentType,
@@ -55,9 +55,9 @@ export async function storeResumeFile(input: {
     return {
       key,
       provider: "r2",
-      url: process.env.R2_PUBLIC_BASE_URL
-        ? `${process.env.R2_PUBLIC_BASE_URL.replace(/\/$/, "")}/${key}`
-        : `r2://${process.env.R2_BUCKET}/${key}`
+      url: storageConfig.publicBaseUrl
+        ? `${storageConfig.publicBaseUrl.replace(/\/$/, "")}/${key}`
+        : `r2://${storageConfig.bucket}/${key}`
     };
   }
 

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { getAuthConfig, getDatabaseConfig, getStorageConfig, validateRuntimeEnvironment } from "@/lib/env";
+
+function createEnv(overrides: Record<string, string | undefined> = {}): NodeJS.ProcessEnv {
+  return {
+    NODE_ENV: "test",
+    ...overrides
+  };
+}
+
+describe("runtime environment validation", () => {
+  it("allows local demo fallbacks outside production", () => {
+    expect(getAuthConfig(createEnv())).toMatchObject({
+      usesLocalDemoSecret: true,
+      usesFallbackUsers: true
+    });
+    expect(getDatabaseConfig(createEnv())).toMatchObject({
+      url: null,
+      usesMemoryFallback: true
+    });
+    expect(getStorageConfig(createEnv())).toEqual({ provider: "local" });
+  });
+
+  it("rejects invalid AUTH_USERS_JSON", () => {
+    expect(() => getAuthConfig(createEnv({ AUTH_USERS_JSON: "{\"bad\":true}" }))).toThrow(
+      /AUTH_USERS_JSON must be a non-empty JSON array/
+    );
+  });
+
+  it("rejects incomplete R2 configuration even in local development", () => {
+    expect(() => getStorageConfig(createEnv({ R2_ACCOUNT_ID: "acct", R2_BUCKET: "bucket" }))).toThrow(
+      /R2 storage configuration is incomplete/
+    );
+  });
+
+  it("requires production envs to opt out of local fallbacks", () => {
+    expect(() => validateRuntimeEnvironment(createEnv({ NODE_ENV: "production" }))).toThrow(
+      /AUTH_USERS_JSON must be configured in production/
+    );
+    expect(() => getDatabaseConfig(createEnv({ NODE_ENV: "production" }))).toThrow(
+      /DATABASE_URL must be configured in production/
+    );
+    expect(() => getStorageConfig(createEnv({ NODE_ENV: "production" }))).toThrow(
+      /R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, and R2_BUCKET must be configured in production/
+    );
+  });
+
+  it("accepts a fully configured production environment", () => {
+    const env = createEnv({
+      NODE_ENV: "production",
+      AUTH_SECRET: "a-production-secret-with-enough-entropy-12345",
+      AUTH_USERS_JSON:
+        '[{"name":"Admin","email":"admin@example.com","role":"system_admin","passwordHash":"scrypt$salt$hash"}]',
+      DATABASE_URL: "postgresql://user:password@example.neon.tech/neondb?sslmode=require",
+      R2_ACCOUNT_ID: "account",
+      R2_ACCESS_KEY_ID: "access",
+      R2_SECRET_ACCESS_KEY: "secret",
+      R2_BUCKET: "resumes",
+      R2_PUBLIC_BASE_URL: "https://cdn.example.com/resumes"
+    });
+
+    expect(validateRuntimeEnvironment(env)).toMatchObject({
+      auth: {
+        secret: "a-production-secret-with-enough-entropy-12345",
+        usesLocalDemoSecret: false,
+        usesFallbackUsers: false
+      },
+      database: {
+        url: "postgresql://user:password@example.neon.tech/neondb?sslmode=require",
+        usesMemoryFallback: false
+      },
+      storage: {
+        provider: "r2",
+        bucket: "resumes",
+        publicBaseUrl: "https://cdn.example.com/resumes"
+      }
+    });
+  });
+});


### PR DESCRIPTION
## What changed
- added central runtime environment validation helpers
- routed auth, credential-user loading, database access, and R2 storage through validated config
- documented production-vs-local expectations and added env-focused tests

## Why
- addresses issue #26 by making invalid env combinations fail clearly instead of silently falling back in production

## Testing
- automated tests were added but not executed in this sandbox because `node_modules` is unavailable here

Closes #26