### PR TITLE
Add saved target role progress tracking

### DIFF
--- a/app/api/saved-roles/route.ts
+++ b/app/api/saved-roles/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+import { getSessionUser } from "@/lib/auth";
+import { deleteSavedTargetRole, listSavedTargetRoles, saveTargetRole } from "@/lib/db";
+import { roles } from "@/lib/seed-data";
+
+export async function GET() {
+  const user = await getSessionUser();
+  if (!user) {
+    return NextResponse.json({ error: "Authentication required." }, { status: 401 });
+  }
+
+  return NextResponse.json({ savedRoles: await listSavedTargetRoles(user.email) });
+}
+
+export async function POST(request: Request) {
+  const user = await getSessionUser();
+  if (!user) {
+    return NextResponse.json({ error: "Authentication required." }, { status: 401 });
+  }
+
+  const payload = (await request.json()) as {
+    roleId?: string;
+    targetScore?: number;
+    currentScore?: number | null;
+    matchedSkills?: string[];
+    missingSkills?: string[];
+  };
+  const role = roles.find((item) => item.id === payload.roleId);
+  if (!role) {
+    return NextResponse.json({ error: "Choose a valid target role." }, { status: 400 });
+  }
+
+  const savedRole = await saveTargetRole({
+    employeeEmail: user.email,
+    roleId: role.id,
+    roleTitle: role.title,
+    targetScore: payload.targetScore,
+    currentScore: payload.currentScore,
+    matchedSkills: payload.matchedSkills,
+    missingSkills: payload.missingSkills
+  });
+
+  return NextResponse.json({ savedRole });
+}
+
+export async function DELETE(request: Request) {
+  const user = await getSessionUser();
+  if (!user) {
+    return NextResponse.json({ error: "Authentication required." }, { status: 401 });
+  }
+
+  const id = new URL(request.url).searchParams.get("id");
+  if (!id) {
+    return NextResponse.json({ error: "Saved role id is required." }, { status: 400 });
+  }
+
+  await deleteSavedTargetRole({ employeeEmail: user.email, id });
+  return NextResponse.json({ ok: true });
+}

--- a/app/dashboard.tsx
+++ b/app/dashboard.tsx
@@ -6,6 +6,7 @@ import {
   Activity,
   AlertTriangle,
   BarChart3,
+  BookmarkCheck,
   BookOpen,
   CheckCircle2,
   ChevronRight,
@@ -17,6 +18,7 @@ import {
   Settings,
   ShieldCheck,
   SlidersHorizontal,
+  Target,
   Trash2,
   UploadCloud,
   Users,
@@ -25,7 +27,7 @@ import {
 } from "lucide-react";
 import { roles } from "@/lib/seed-data";
 import type { SessionUser } from "@/lib/auth-model";
-import type { AnalysisRecord, AuditEvent } from "@/lib/db";
+import type { AnalysisRecord, AuditEvent, SavedTargetRole } from "@/lib/db";
 import type { CandidateAnalysis } from "@/lib/skillmatch";
 
 type UploadResponse = {
@@ -62,6 +64,7 @@ export default function Dashboard({ user }: { user: SessionUser }) {
   const [files, setFiles] = useState<File[]>([]);
   const [candidates, setCandidates] = useState<CandidateAnalysis[]>([]);
   const [analyses, setAnalyses] = useState<AnalysisRecord[]>([]);
+  const [savedRoles, setSavedRoles] = useState<SavedTargetRole[]>([]);
   const [auditEvents, setAuditEvents] = useState<AuditEvent[]>([]);
   const [failures, setFailures] = useState<UploadResponse["failures"]>([]);
   const [selectedCandidateId, setSelectedCandidateId] = useState<string>("");
@@ -74,6 +77,7 @@ export default function Dashboard({ user }: { user: SessionUser }) {
   const selectedRoleMatch = selectedCandidate?.topPositions.find((item) => item.role.id === roleId);
   const bestRecommendation = selectedRoleMatch ?? selectedCandidate?.topPositions[0];
   const selectedResult = selectedRoleMatch ?? bestRecommendation;
+  const savedCurrentRole = savedRoles.find((role) => role.roleId === roleId);
 
   const workforceGaps = useMemo(() => {
     const counts = new Map<string, number>();
@@ -118,9 +122,10 @@ export default function Dashboard({ user }: { user: SessionUser }) {
 
   const refreshRecords = useCallback(async () => {
     const auditRequest = user.role === "system_admin" ? fetch("/api/audit") : Promise.resolve(null);
-    const [candidateResponse, analysisResponse, auditResponse] = await Promise.all([
+    const [candidateResponse, analysisResponse, savedRolesResponse, auditResponse] = await Promise.all([
       fetch("/api/candidates"),
       fetch("/api/analyses"),
+      fetch("/api/saved-roles"),
       auditRequest
     ]);
 
@@ -133,6 +138,11 @@ export default function Dashboard({ user }: { user: SessionUser }) {
     if (analysisResponse.ok) {
       const payload = (await analysisResponse.json()) as { analyses: AnalysisRecord[] };
       setAnalyses(payload.analyses);
+    }
+
+    if (savedRolesResponse.ok) {
+      const payload = (await savedRolesResponse.json()) as { savedRoles: SavedTargetRole[] };
+      setSavedRoles(payload.savedRoles);
     }
 
     if (auditResponse?.ok) {
@@ -211,6 +221,36 @@ export default function Dashboard({ user }: { user: SessionUser }) {
     );
     setIsUploading(false);
     void refreshRecords();
+  }
+
+  async function saveCurrentTargetRole() {
+    const response = await fetch("/api/saved-roles", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        roleId,
+        targetScore: 80,
+        currentScore: selectedResult?.score ?? null,
+        matchedSkills,
+        missingSkills: missingSkills.map((gap) => gap.skill)
+      })
+    });
+
+    if (!response.ok) {
+      setNotice("Could not save this target role.");
+      return;
+    }
+
+    const payload = (await response.json()) as { savedRole: SavedTargetRole };
+    setSavedRoles((current) => [payload.savedRole, ...current.filter((role) => role.id !== payload.savedRole.id)]);
+    setNotice(`${selectedRole.title} saved as a target role.`);
+  }
+
+  async function removeSavedRole(id: string) {
+    const response = await fetch(`/api/saved-roles?id=${encodeURIComponent(id)}`, { method: "DELETE" });
+    if (response.ok) {
+      setSavedRoles((current) => current.filter((role) => role.id !== id));
+    }
   }
 
   async function logout() {
@@ -373,6 +413,16 @@ export default function Dashboard({ user }: { user: SessionUser }) {
               </section>
 
               <aside className="right-stack">
+                <SavedTargetRolesPanel
+                  currentRoleSaved={Boolean(savedCurrentRole)}
+                  roles={savedRoles}
+                  onRemove={removeSavedRole}
+                  onSave={saveCurrentTargetRole}
+                  onSelect={(id) => {
+                    setRoleId(id);
+                    setView("learning");
+                  }}
+                />
                 <RecommendationPanel candidate={selectedCandidate} />
                 <RecentCandidates candidates={candidates} onSelect={setSelectedCandidateId} />
               </aside>
@@ -409,6 +459,11 @@ export default function Dashboard({ user }: { user: SessionUser }) {
 
         {view === "learning" ? (
           <section className="screen-stack">
+            <section className="metric-grid">
+              <Metric label="Saved target roles" value={savedRoles.length} />
+              <Metric label="Current role progress" value={savedCurrentRole ? `${savedCurrentRole.progressPercent}%` : "Not saved"} />
+              <Metric label="Target match score" value={savedCurrentRole ? `${savedCurrentRole.targetScore}%` : "80%"} />
+            </section>
             <section className="concept-panel">
               <div className="panel-heading">
                 <h2>Learning Recommendations</h2>
@@ -426,6 +481,7 @@ export default function Dashboard({ user }: { user: SessionUser }) {
                 ))}
               </div>
             </section>
+            <SavedRoleProgress roles={savedRoles} onRemove={removeSavedRole} onSelect={setRoleId} />
           </section>
         ) : null}
 
@@ -652,6 +708,102 @@ function RoleSkillGapChart({
           </span>
         </figcaption>
       </figure>
+    </section>
+  );
+}
+
+function SavedTargetRolesPanel({
+  currentRoleSaved,
+  roles,
+  onRemove,
+  onSave,
+  onSelect
+}: {
+  currentRoleSaved: boolean;
+  roles: SavedTargetRole[];
+  onRemove: (id: string) => void;
+  onSave: () => void;
+  onSelect: (roleId: string) => void;
+}) {
+  return (
+    <section className="concept-panel saved-target-panel">
+      <div className="panel-heading">
+        <h2>Saved Target Roles</h2>
+        <span>{roles.length}</span>
+      </div>
+      <button className="primary-action" type="button" onClick={onSave}>
+        <BookmarkCheck aria-hidden="true" />
+        {currentRoleSaved ? "Update target progress" : "Save current target"}
+      </button>
+      {roles.length ? (
+        <ul className="saved-role-list">
+          {roles.slice(0, 3).map((role) => (
+            <li key={role.id}>
+              <button type="button" onClick={() => onSelect(role.roleId)}>
+                <Target aria-hidden="true" />
+                <span>
+                  <strong>{role.roleTitle}</strong>
+                  <small>{role.currentScore === null ? "No score yet" : `${role.currentScore}% current match`}</small>
+                </span>
+                <em>{role.progressPercent}%</em>
+              </button>
+              <button
+                aria-label={`Remove ${role.roleTitle}`}
+                className="queue-icon-button"
+                onClick={() => onRemove(role.id)}
+                title={`Remove ${role.roleTitle}`}
+                type="button"
+              >
+                <X aria-hidden="true" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="list-placeholder">Save target roles to track skill progress over time.</p>
+      )}
+    </section>
+  );
+}
+
+function SavedRoleProgress({
+  roles,
+  onRemove,
+  onSelect
+}: {
+  roles: SavedTargetRole[];
+  onRemove: (id: string) => void;
+  onSelect: (roleId: string) => void;
+}) {
+  return (
+    <section className="concept-panel">
+      <div className="panel-heading">
+        <h2>Target Role Progress</h2>
+        <span>{roles.length ? "Employee plan" : "No saved targets"}</span>
+      </div>
+      {roles.length ? (
+        <div className="saved-progress-grid">
+          {roles.map((role) => (
+            <article key={role.id}>
+              <div>
+                <strong>{role.roleTitle}</strong>
+                <span>{role.missingSkills.length ? `${role.missingSkills.slice(0, 3).join(", ")} gaps` : "No tracked gaps"}</span>
+              </div>
+              <meter min={0} max={100} value={role.progressPercent} />
+              <em>{role.progressPercent}% to {role.targetScore}% goal</em>
+              <button className="icon-text-button" type="button" onClick={() => onSelect(role.roleId)}>
+                <Target aria-hidden="true" />
+                View learning
+              </button>
+              <button className="queue-icon-button" type="button" onClick={() => onRemove(role.id)} aria-label={`Remove ${role.roleTitle}`}>
+                <Trash2 aria-hidden="true" />
+              </button>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <EmptyPanel title="No saved target roles" text="Save a role from the dashboard to start tracking employee progress." />
+      )}
     </section>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -618,7 +618,8 @@ input:focus-visible {
 .match-table,
 .gap-table,
 .recommendation-list,
-.recent-list {
+.recent-list,
+.saved-role-list {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -1087,6 +1088,100 @@ input:focus-visible {
 .right-stack {
   display: grid;
   gap: 14px;
+}
+
+.saved-target-panel {
+  display: grid;
+  gap: 12px;
+}
+
+.saved-role-list {
+  display: grid;
+  gap: 8px;
+}
+
+.saved-role-list li {
+  display: grid;
+  grid-template-columns: 1fr 24px;
+  gap: 8px;
+  align-items: center;
+}
+
+.saved-role-list li > button:first-child {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  min-height: 54px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--panel);
+  color: var(--ink);
+  padding: 8px 10px;
+  text-align: left;
+}
+
+.saved-role-list svg {
+  color: var(--blue);
+}
+
+.saved-role-list span {
+  display: grid;
+  min-width: 0;
+}
+
+.saved-role-list strong,
+.saved-progress-grid strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12.5px;
+}
+
+.saved-role-list small,
+.saved-progress-grid span {
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 11.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.saved-role-list em,
+.saved-progress-grid em {
+  border-radius: var(--radius-sm);
+  background: var(--blue-bg);
+  color: var(--blue);
+  padding: 3px 7px;
+  font-size: 11.5px;
+  font-style: normal;
+  font-weight: 700;
+}
+
+.saved-progress-grid {
+  display: grid;
+  gap: 10px;
+}
+
+.saved-progress-grid article {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(120px, 0.6fr) auto auto 28px;
+  gap: 10px;
+  align-items: center;
+  min-height: 58px;
+  border-top: 1px solid var(--border);
+  padding-top: 10px;
+}
+
+.saved-progress-grid article:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.saved-progress-grid article > div {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
 }
 
 .recommendation-list {
@@ -1667,6 +1762,7 @@ meter::-moz-meter-bar {
   .overview-content,
   .overview-summary,
   .audit-log-row,
+  .saved-progress-grid article,
   .system-health,
   .screen-toolbar,
   .search-box {

--- a/db/migrations/0002_saved_target_roles.sql
+++ b/db/migrations/0002_saved_target_roles.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "saved_target_roles" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"employee_email" text NOT NULL,
+	"role_id" text NOT NULL,
+	"role_title" text NOT NULL,
+	"target_score" integer DEFAULT 80 NOT NULL,
+	"current_score" integer,
+	"matched_skills" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"missing_skills" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"progress_percent" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "saved_target_roles_target_score_check" CHECK ("saved_target_roles"."target_score" >= 1 and "saved_target_roles"."target_score" <= 100),
+	CONSTRAINT "saved_target_roles_current_score_check" CHECK ("saved_target_roles"."current_score" is null or ("saved_target_roles"."current_score" >= 0 and "saved_target_roles"."current_score" <= 100)),
+	CONSTRAINT "saved_target_roles_progress_percent_check" CHECK ("saved_target_roles"."progress_percent" >= 0 and "saved_target_roles"."progress_percent" <= 100)
+);
+--> statement-breakpoint
+CREATE INDEX "saved_target_roles_employee_idx" ON "saved_target_roles" USING btree ("employee_email");--> statement-breakpoint
+CREATE UNIQUE INDEX "saved_target_roles_employee_role_idx" ON "saved_target_roles" USING btree ("employee_email","role_id");

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1777608604595,
       "tag": "0001_handy_pete_wisdom",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1777680000000,
+      "tag": "0002_saved_target_roles",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -41,9 +41,25 @@ create table if not exists candidate_recommendations (
   created_at timestamptz not null default now()
 );
 
+create table if not exists saved_target_roles (
+  id uuid primary key,
+  employee_email text not null,
+  role_id text not null,
+  role_title text not null,
+  target_score integer not null default 80 check (target_score >= 1 and target_score <= 100),
+  current_score integer check (current_score is null or (current_score >= 0 and current_score <= 100)),
+  matched_skills jsonb not null default '[]'::jsonb,
+  missing_skills jsonb not null default '[]'::jsonb,
+  progress_percent integer not null default 0 check (progress_percent >= 0 and progress_percent <= 100),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
 create index if not exists analyses_created_at_idx on analyses (created_at desc);
 create index if not exists analyses_target_role_idx on analyses (target_role_id);
 create index if not exists audit_events_created_at_idx on audit_events (created_at desc);
 create index if not exists candidate_recommendations_created_at_idx on candidate_recommendations (created_at desc);
 create index if not exists candidate_recommendations_best_score_idx on candidate_recommendations (best_score desc);
+create index if not exists saved_target_roles_employee_idx on saved_target_roles (employee_email);
+create unique index if not exists saved_target_roles_employee_role_idx on saved_target_roles (employee_email, role_id);
 create unique index if not exists users_email_idx on users (email);

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -67,3 +67,33 @@ export const candidateRecommendations = pgTable(
     check("candidate_recommendations_best_score_check", sql`${table.bestScore} >= 0 and ${table.bestScore} <= 100`)
   ]
 );
+
+export const savedTargetRoles = pgTable(
+  "saved_target_roles",
+  {
+    id: uuid("id").primaryKey(),
+    employeeEmail: text("employee_email").notNull(),
+    roleId: text("role_id").notNull(),
+    roleTitle: text("role_title").notNull(),
+    targetScore: integer("target_score").notNull().default(80),
+    currentScore: integer("current_score"),
+    matchedSkills: jsonb("matched_skills").$type<string[]>().notNull().default(sql`'[]'::jsonb`),
+    missingSkills: jsonb("missing_skills").$type<string[]>().notNull().default(sql`'[]'::jsonb`),
+    progressPercent: integer("progress_percent").notNull().default(0),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow()
+  },
+  (table) => [
+    uniqueIndex("saved_target_roles_employee_role_idx").on(table.employeeEmail, table.roleId),
+    index("saved_target_roles_employee_idx").on(table.employeeEmail),
+    check("saved_target_roles_target_score_check", sql`${table.targetScore} >= 1 and ${table.targetScore} <= 100`),
+    check(
+      "saved_target_roles_current_score_check",
+      sql`${table.currentScore} is null or (${table.currentScore} >= 0 and ${table.currentScore} <= 100)`
+    ),
+    check(
+      "saved_target_roles_progress_percent_check",
+      sql`${table.progressPercent} >= 0 and ${table.progressPercent} <= 100`
+    )
+  ]
+);

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,5 +1,5 @@
-import { desc } from "drizzle-orm";
-import { analyses, auditEvents, candidateRecommendations } from "@/db/schema";
+import { and, desc, eq } from "drizzle-orm";
+import { analyses, auditEvents, candidateRecommendations, savedTargetRoles } from "@/db/schema";
 import { getDatabase } from "./database";
 import type { CandidateAnalysis, SkillMatchResult } from "./skillmatch";
 
@@ -16,6 +16,7 @@ export type AnalysisRecord = {
 const memoryStore: AnalysisRecord[] = [];
 const memoryCandidates: CandidateAnalysis[] = [];
 const memoryAuditEvents: AuditEvent[] = [];
+const memorySavedTargetRoles: SavedTargetRole[] = [];
 
 export type AuditEvent = {
   id: string;
@@ -25,6 +26,32 @@ export type AuditEvent = {
   details: Record<string, unknown>;
   createdAt: string;
 };
+
+export type SavedTargetRole = {
+  id: string;
+  employeeEmail: string;
+  roleId: string;
+  roleTitle: string;
+  targetScore: number;
+  currentScore: number | null;
+  matchedSkills: string[];
+  missingSkills: string[];
+  progressPercent: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+function clampScore(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, Math.round(value)));
+}
+
+function calculateProgress(currentScore: number | null, targetScore: number) {
+  if (currentScore === null) {
+    return 0;
+  }
+
+  return clampScore((currentScore / targetScore) * 100, 0, 100);
+}
 
 export async function saveAnalysis(input: {
   employeeName: string;
@@ -230,4 +257,138 @@ export async function listAnalyses() {
     missingSkills: row.missingSkills,
     createdAt: row.createdAt.toISOString()
   })) satisfies AnalysisRecord[];
+}
+
+export async function listSavedTargetRoles(employeeEmail: string) {
+  const db = getDatabase();
+  if (!db) {
+    return memorySavedTargetRoles
+      .filter((role) => role.employeeEmail === employeeEmail)
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  }
+
+  const rows = await db
+    .select({
+      id: savedTargetRoles.id,
+      employeeEmail: savedTargetRoles.employeeEmail,
+      roleId: savedTargetRoles.roleId,
+      roleTitle: savedTargetRoles.roleTitle,
+      targetScore: savedTargetRoles.targetScore,
+      currentScore: savedTargetRoles.currentScore,
+      matchedSkills: savedTargetRoles.matchedSkills,
+      missingSkills: savedTargetRoles.missingSkills,
+      progressPercent: savedTargetRoles.progressPercent,
+      createdAt: savedTargetRoles.createdAt,
+      updatedAt: savedTargetRoles.updatedAt
+    })
+    .from(savedTargetRoles)
+    .where(eq(savedTargetRoles.employeeEmail, employeeEmail))
+    .orderBy(desc(savedTargetRoles.updatedAt));
+
+  return rows.map((row) => ({
+    ...row,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString()
+  })) satisfies SavedTargetRole[];
+}
+
+export async function saveTargetRole(input: {
+  employeeEmail: string;
+  roleId: string;
+  roleTitle: string;
+  targetScore?: number;
+  currentScore?: number | null;
+  matchedSkills?: string[];
+  missingSkills?: string[];
+}) {
+  const now = new Date().toISOString();
+  const targetScore = clampScore(input.targetScore ?? 80, 1, 100);
+  const currentScore = input.currentScore == null ? null : clampScore(input.currentScore, 0, 100);
+  const progressPercent = calculateProgress(currentScore, targetScore);
+  const existing = (await listSavedTargetRoles(input.employeeEmail)).find((role) => role.roleId === input.roleId);
+  const record: SavedTargetRole = {
+    id: existing?.id ?? crypto.randomUUID(),
+    employeeEmail: input.employeeEmail,
+    roleId: input.roleId,
+    roleTitle: input.roleTitle,
+    targetScore,
+    currentScore,
+    matchedSkills: input.matchedSkills ?? existing?.matchedSkills ?? [],
+    missingSkills: input.missingSkills ?? existing?.missingSkills ?? [],
+    progressPercent,
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now
+  };
+
+  const db = getDatabase();
+  if (!db) {
+    const index = memorySavedTargetRoles.findIndex(
+      (role) => role.employeeEmail === input.employeeEmail && role.roleId === input.roleId
+    );
+    if (index >= 0) {
+      memorySavedTargetRoles[index] = record;
+    } else {
+      memorySavedTargetRoles.unshift(record);
+    }
+    return record;
+  }
+
+  if (existing) {
+    await db
+      .update(savedTargetRoles)
+      .set({
+        roleTitle: record.roleTitle,
+        targetScore: record.targetScore,
+        currentScore: record.currentScore,
+        matchedSkills: record.matchedSkills,
+        missingSkills: record.missingSkills,
+        progressPercent: record.progressPercent,
+        updatedAt: new Date()
+      })
+      .where(and(eq(savedTargetRoles.employeeEmail, input.employeeEmail), eq(savedTargetRoles.roleId, input.roleId)));
+  } else {
+    await db.insert(savedTargetRoles).values({
+      id: record.id,
+      employeeEmail: record.employeeEmail,
+      roleId: record.roleId,
+      roleTitle: record.roleTitle,
+      targetScore: record.targetScore,
+      currentScore: record.currentScore,
+      matchedSkills: record.matchedSkills,
+      missingSkills: record.missingSkills,
+      progressPercent: record.progressPercent
+    });
+  }
+
+  await appendAuditEvent({
+    actor: input.employeeEmail,
+    action: "saved_target_role_upsert",
+    entityId: record.id,
+    details: { roleId: input.roleId, roleTitle: input.roleTitle, progressPercent }
+  });
+
+  return record;
+}
+
+export async function deleteSavedTargetRole(input: { employeeEmail: string; id: string }) {
+  const db = getDatabase();
+  if (!db) {
+    const index = memorySavedTargetRoles.findIndex(
+      (role) => role.employeeEmail === input.employeeEmail && role.id === input.id
+    );
+    if (index === -1) {
+      return false;
+    }
+    memorySavedTargetRoles.splice(index, 1);
+    return true;
+  }
+
+  await db
+    .delete(savedTargetRoles)
+    .where(and(eq(savedTargetRoles.employeeEmail, input.employeeEmail), eq(savedTargetRoles.id, input.id)));
+  return true;
+}
+
+export function resetSavedTargetRolesForTests() {
+  memorySavedTargetRoles.length = 0;
 }

--- a/tests/saved-target-roles.test.ts
+++ b/tests/saved-target-roles.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { deleteSavedTargetRole, listSavedTargetRoles, resetSavedTargetRolesForTests, saveTargetRole } from "@/lib/db";
+
+describe("saved target role progress tracking", () => {
+  beforeEach(() => {
+    resetSavedTargetRolesForTests();
+  });
+
+  it("saves employee target roles with progress toward the target score", async () => {
+    const saved = await saveTargetRole({
+      employeeEmail: "alex@example.com",
+      roleId: "sde-ii",
+      roleTitle: "Software Development Engineer II",
+      targetScore: 80,
+      currentScore: 60,
+      matchedSkills: ["java", "aws"],
+      missingSkills: ["system design"]
+    });
+
+    expect(saved.progressPercent).toBe(75);
+    expect(saved.matchedSkills).toEqual(["java", "aws"]);
+    expect(await listSavedTargetRoles("alex@example.com")).toHaveLength(1);
+    expect(await listSavedTargetRoles("other@example.com")).toEqual([]);
+  });
+
+  it("updates an existing saved role for the same employee and role", async () => {
+    const first = await saveTargetRole({
+      employeeEmail: "alex@example.com",
+      roleId: "data-analyst",
+      roleTitle: "Data Analyst",
+      currentScore: 20
+    });
+    const updated = await saveTargetRole({
+      employeeEmail: "alex@example.com",
+      roleId: "data-analyst",
+      roleTitle: "Data Analyst",
+      targetScore: 50,
+      currentScore: 55,
+      matchedSkills: ["sql"]
+    });
+
+    const roles = await listSavedTargetRoles("alex@example.com");
+    expect(roles).toHaveLength(1);
+    expect(updated.id).toBe(first.id);
+    expect(roles[0].progressPercent).toBe(100);
+    expect(roles[0].matchedSkills).toEqual(["sql"]);
+  });
+
+  it("deletes only the requesting employee's saved role", async () => {
+    const saved = await saveTargetRole({
+      employeeEmail: "alex@example.com",
+      roleId: "cloud-support",
+      roleTitle: "Cloud Support Associate"
+    });
+    await saveTargetRole({
+      employeeEmail: "jamie@example.com",
+      roleId: "cloud-support",
+      roleTitle: "Cloud Support Associate"
+    });
+
+    expect(await deleteSavedTargetRole({ employeeEmail: "jamie@example.com", id: saved.id })).toBe(false);
+    expect(await deleteSavedTargetRole({ employeeEmail: "alex@example.com", id: saved.id })).toBe(true);
+    expect(await listSavedTargetRoles("alex@example.com")).toEqual([]);
+    expect(await listSavedTargetRoles("jamie@example.com")).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## What changed
- Added saved target role persistence for employees, including progress, current match score, matched skills, and missing skills.
- Added `/api/saved-roles` GET/POST/DELETE helpers backed by database or local memory mode.
- Added dashboard and learning UI states for saving target roles, updating progress, selecting saved roles, and removing saved roles.
- Added focused Vitest coverage for saved target role progress behavior.

## Why
Employees need to save role goals and track progress toward readiness over time instead of only seeing one-off role-fit analysis.

## Testing
- `npm test`
- `npm run lint`
- `npm run build`

Closes #32