### PR TITLE
Mirror upload scoring rows into analysis history (Fixes #11)

### DIFF
--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 import { getSessionUser } from "@/lib/auth";
-import { saveCandidateBatch } from "@/lib/db";
+import { saveAnalysis, saveCandidateBatch } from "@/lib/db";
 import { extractResumeText } from "@/lib/resume-parser";
-import { analyzeCandidateResume } from "@/lib/skillmatch";
+import { analyzeCandidateResume, type CandidateAnalysis } from "@/lib/skillmatch";
 import { storeResumeFile } from "@/lib/storage";
 
 const maxFiles = 12;
@@ -35,6 +35,7 @@ export async function POST(request: Request) {
   }
 
   const candidates = [];
+  const uploadOutputs: { candidate: CandidateAnalysis; resumeText: string }[] = [];
   const failures = [];
 
   for (const file of files) {
@@ -57,13 +58,13 @@ export async function POST(request: Request) {
         contentType: file.type || "application/octet-stream",
         bytes: parsed.bytes
       });
-      candidates.push(
-        analyzeCandidateResume({
-          fileName: file.name,
-          resumeText: parsed.text,
-          storageUrl: stored.url
-        })
-      );
+      const candidate = analyzeCandidateResume({
+        fileName: file.name,
+        resumeText: parsed.text,
+        storageUrl: stored.url
+      });
+      candidates.push(candidate);
+      uploadOutputs.push({ candidate, resumeText: parsed.text });
     } catch (error) {
       failures.push({
         fileName: file.name,
@@ -74,6 +75,17 @@ export async function POST(request: Request) {
 
   if (candidates.length) {
     await saveCandidateBatch({ actor: user.email, candidates });
+    for (const { candidate, resumeText } of uploadOutputs) {
+      const best = candidate.topPositions[0];
+      if (best) {
+        await saveAnalysis({
+          employeeName: candidate.candidateName,
+          resumeText,
+          result: best,
+          recordAudit: false
+        });
+      }
+    }
   }
 
   return NextResponse.json({ candidates, failures });

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -93,7 +93,11 @@ export async function saveAnalysis(input: {
   employeeName: string;
   resumeText: string;
   result: SkillMatchResult;
+  recordAudit?: boolean;
+  auditActor?: string;
 }) {
+  const recordAudit = input.recordAudit !== false;
+  const auditActor = input.auditActor ?? input.employeeName;
   const record: AnalysisRecord = {
     id: crypto.randomUUID(),
     employeeName: input.employeeName,
@@ -122,12 +126,14 @@ export async function saveAnalysis(input: {
     explanation: input.result.explanation
   });
 
-  await db.insert(auditEvents).values({
-    actor: input.employeeName,
-    action: "recommendation_generation",
-    entityId: record.id,
-    details: { targetRole: input.result.role.title, score: input.result.score }
-  });
+  if (recordAudit) {
+    await db.insert(auditEvents).values({
+      actor: auditActor,
+      action: "recommendation_generation",
+      entityId: record.id,
+      details: { targetRole: input.result.role.title, score: input.result.score }
+    });
+  }
 
   return record;
 }
@@ -429,4 +435,8 @@ export async function deleteSavedTargetRole(input: { employeeEmail: string; id: 
 
 export function resetSavedTargetRolesForTests() {
   memorySavedTargetRoles.length = 0;
+}
+
+export function resetAnalysesForTests() {
+  memoryStore.length = 0;
 }

--- a/tests/upload-analysis-history.test.ts
+++ b/tests/upload-analysis-history.test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { analyzeResume } from "@/lib/skillmatch";
+import { listAnalyses, resetAnalysesForTests, saveAnalysis } from "@/lib/db";
+
+describe("analysis history alignment with uploads", () => {
+  beforeEach(() => {
+    resetAnalysesForTests();
+  });
+
+  it("records an analysis row when saveAnalysis skips upload-scoped audit noise", async () => {
+    const resumeText = `${"x".repeat(25)} Java engineer with AWS, SQL, Docker, and distributed systems experience.`;
+    const result = analyzeResume(resumeText, "sde-i");
+
+    await saveAnalysis({
+      employeeName: "Taylor Uploaded",
+      resumeText,
+      result,
+      recordAudit: false
+    });
+
+    const history = await listAnalyses();
+    expect(history.some((row) => row.employeeName === "Taylor Uploaded")).toBe(true);
+  });
+});


### PR DESCRIPTION
- Extend saveAnalysis with optional auditActor/recordAudit so bulk uploads can skip duplicate recommendation_generation audit noise.
- After a successful candidate batch save, persist the top-ranked role analysis for each uploaded resume into the analyses table.
- Add resetAnalysesForTests plus a regression test for the memory-store path.

## Summary

- Describe what changed.
- Describe why the change was needed.

## Testing

- List the checks you ran.
- Note any checks you could not run.

## Documentation

- [ ] I updated `README.md` or `docs/*` when behavior, architecture, testing, or deployment expectations changed.
- [ ] I added or skipped a `docs/changelog.md` entry with a short reason.
- [ ] I organized any source Office docs under `docs/source/` and any committed exports under `docs/generated/`.
