### PR TITLE
Add authenticated resume download for stored candidates (Fixes #17)

### DIFF
--- a/app/api/candidates/[id]/resume/route.ts
+++ b/app/api/candidates/[id]/resume/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import { canAccess, getSessionUser } from "@/lib/auth";
+import { getCandidateResumeById } from "@/lib/db";
+import { getResumeObject } from "@/lib/storage";
+
+function contentTypeForResumeFile(fileName: string) {
+  const lower = fileName.toLowerCase();
+  if (lower.endsWith(".pdf")) {
+    return "application/pdf";
+  }
+  if (lower.endsWith(".docx")) {
+    return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+  }
+  if (lower.endsWith(".txt")) {
+    return "text/plain";
+  }
+  return null;
+}
+
+function safeAttachmentName(fileName: string) {
+  const trimmed = fileName.trim() || "resume";
+  return trimmed.replace(/[\r\n"]/g, "_");
+}
+
+export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getSessionUser();
+  if (!canAccess(user, "recruiter")) {
+    return NextResponse.json({ error: "Authentication required." }, { status: user ? 403 : 401 });
+  }
+
+  const { id } = await params;
+
+  const meta = await getCandidateResumeById(id);
+  if (!meta) {
+    return NextResponse.json({ error: "Candidate not found." }, { status: 404 });
+  }
+
+  const object = await getResumeObject(meta.storageUrl);
+  if (!object) {
+    return NextResponse.json({ error: "Resume file unavailable." }, { status: 404 });
+  }
+
+  const fallbackType = contentTypeForResumeFile(meta.fileName);
+  const contentType =
+    object.contentType && object.contentType !== "application/octet-stream"
+      ? object.contentType
+      : (fallbackType ?? "application/octet-stream");
+
+  const attachmentName = safeAttachmentName(meta.fileName);
+
+  return new NextResponse(Buffer.from(object.bytes), {
+    status: 200,
+    headers: {
+      "Content-Type": contentType,
+      "Content-Disposition": `attachment; filename="${attachmentName}"`
+    }
+  });
+}

--- a/app/dashboard.tsx
+++ b/app/dashboard.tsx
@@ -491,7 +491,12 @@ export default function Dashboard({ user }: { user: SessionUser }) {
                     <h2>{candidate.candidateName}</h2>
                     <em className="status-chip">{candidate.topPositions[0]?.score ?? 0}%</em>
                   </div>
-                  <p>{candidate.fileName}</p>
+                  <p>
+                    {candidate.fileName}{" "}
+                    <a className="resume-download-link" href={`/api/candidates/${candidate.id}/resume`}>
+                      Download original
+                    </a>
+                  </p>
                   <strong style={{ fontSize: "13px" }}>{candidate.topPositions[0]?.role.title ?? "No recommendation"}</strong>
                   <span className="candidate-meta">
                     {(candidate.structured.skills.slice(0, 4).join(", ") || "No skills extracted")}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1526,6 +1526,17 @@ meter::-moz-meter-bar {
   line-height: 1.55;
 }
 
+.resume-download-link {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--blue);
+  text-decoration: none;
+}
+
+.resume-download-link:hover {
+  text-decoration: underline;
+}
+
 .learning-grid {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -236,6 +236,35 @@ export async function listCandidateRecommendations(filters: CandidateRecommendat
   return filterCandidateRecommendations(candidates, filters).slice(0, 20);
 }
 
+export async function getCandidateResumeById(candidateId: string) {
+  const db = getDatabase();
+
+  if (!db) {
+    const candidate = memoryCandidates.find((item) => item.id === candidateId);
+    return candidate
+      ? { fileName: candidate.fileName, storageUrl: candidate.storageUrl }
+      : null;
+  }
+
+  const rows = await db
+    .select({
+      fileName: candidateRecommendations.fileName,
+      storageUrl: candidateRecommendations.storageUrl
+    })
+    .from(candidateRecommendations)
+    .where(eq(candidateRecommendations.id, candidateId))
+    .limit(1);
+
+  if (!rows.length) {
+    return null;
+  }
+
+  return {
+    fileName: rows[0].fileName,
+    storageUrl: rows[0].storageUrl
+  };
+}
+
 export async function listAuditEvents() {
   const db = getDatabase();
 

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,4 +1,4 @@
-import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import { GetObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { getStorageConfig } from "./env";
 
 type StoredObject = {
@@ -25,6 +25,104 @@ function getR2Client() {
 
 function safeFileName(fileName: string) {
   return fileName.replace(/[^a-z0-9_.-]/gi, "_").toLowerCase();
+}
+
+function resolveStoredObjectKey(storageUrl: string, bucket: string) {
+  if (storageUrl.startsWith("local://")) {
+    return storageUrl.slice("local://".length);
+  }
+
+  if (storageUrl.startsWith("r2://")) {
+    const withoutScheme = storageUrl.slice("r2://".length);
+    const slash = withoutScheme.indexOf("/");
+    if (slash === -1) {
+      return null;
+    }
+
+    const maybeBucket = withoutScheme.slice(0, slash);
+    const objectKey = withoutScheme.slice(slash + 1);
+    if (!objectKey || maybeBucket !== bucket) {
+      return null;
+    }
+
+    return objectKey;
+  }
+
+  return null;
+}
+
+function resolvePublicObjectKey(storageUrl: string, publicBaseUrl: string | undefined) {
+  if (!publicBaseUrl) {
+    return null;
+  }
+
+  const base = publicBaseUrl.replace(/\/$/, "");
+  if (!storageUrl.startsWith(`${base}/`)) {
+    return null;
+  }
+
+  return storageUrl.slice(base.length + 1);
+}
+
+export async function getResumeObject(storageUrl: string): Promise<{
+  bytes: Uint8Array;
+  contentType: string;
+} | null> {
+  let storageConfig;
+  try {
+    storageConfig = getStorageConfig();
+  } catch {
+    return null;
+  }
+
+  if (storageConfig.provider === "local") {
+    if (!storageUrl.startsWith("local://")) {
+      return null;
+    }
+
+    const key = storageUrl.slice("local://".length);
+
+    const bytes = localObjects.get(key);
+    if (!bytes) {
+      return null;
+    }
+
+    return { bytes, contentType: "application/octet-stream" };
+  }
+
+  const client = getR2Client();
+  if (!client) {
+    return null;
+  }
+
+  const bucket = storageConfig.bucket;
+  const keyFromR2 = resolveStoredObjectKey(storageUrl, bucket);
+  const keyFromPublic = resolvePublicObjectKey(storageUrl, storageConfig.publicBaseUrl ?? undefined);
+  const key = keyFromR2 ?? keyFromPublic;
+
+  if (!key) {
+    return null;
+  }
+
+  try {
+    const response = await client.send(
+      new GetObjectCommand({
+        Bucket: bucket,
+        Key: key
+      })
+    );
+
+    if (!response.Body) {
+      return null;
+    }
+
+    const bytes = new Uint8Array(await response.Body.transformToByteArray());
+    const contentType = response.ContentType?.trim() || "application/octet-stream";
+
+    return { bytes, contentType };
+  } catch {
+    return null;
+  }
 }
 
 export async function storeResumeFile(input: {

--- a/tests/candidate-resume-download.test.ts
+++ b/tests/candidate-resume-download.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetSessionUser, mockGetCandidateResumeById, mockGetResumeObject } = vi.hoisted(() => ({
+  mockGetSessionUser: vi.fn(),
+  mockGetCandidateResumeById: vi.fn(),
+  mockGetResumeObject: vi.fn()
+}));
+
+vi.mock("@/lib/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/auth")>();
+  return {
+    ...actual,
+    getSessionUser: mockGetSessionUser
+  };
+});
+
+vi.mock("@/lib/db", () => ({
+  getCandidateResumeById: mockGetCandidateResumeById
+}));
+
+vi.mock("@/lib/storage", () => ({
+  getResumeObject: mockGetResumeObject
+}));
+
+import { GET as downloadResumeGet } from "@/app/api/candidates/[id]/resume/route";
+
+describe("GET /api/candidates/[id]/resume", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when signed out", async () => {
+    mockGetSessionUser.mockResolvedValue(null);
+
+    const response = await downloadResumeGet(new Request("http://localhost/api/candidates/x/resume"), {
+      params: Promise.resolve({ id: "x" })
+    });
+
+    expect(response.status).toBe(401);
+    expect(mockGetCandidateResumeById).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when candidate is missing", async () => {
+    mockGetSessionUser.mockResolvedValue({
+      name: "Recruiter",
+      email: "recruiter@skillmatch.demo",
+      role: "recruiter"
+    });
+    mockGetCandidateResumeById.mockResolvedValue(null);
+
+    const response = await downloadResumeGet(new Request("http://localhost/api/candidates/missing/resume"), {
+      params: Promise.resolve({ id: "missing" })
+    });
+
+    expect(response.status).toBe(404);
+    expect(mockGetResumeObject).not.toHaveBeenCalled();
+  });
+
+  it("streams bytes when resume object resolves", async () => {
+    mockGetSessionUser.mockResolvedValue({
+      name: "Recruiter",
+      email: "recruiter@skillmatch.demo",
+      role: "recruiter"
+    });
+    mockGetCandidateResumeById.mockResolvedValue({
+      fileName: "Alex-Smith.pdf",
+      storageUrl: "local://resumes/2026-01-01/x.pdf"
+    });
+    mockGetResumeObject.mockResolvedValue({
+      bytes: new Uint8Array([1, 2, 3]),
+      contentType: "application/pdf"
+    });
+
+    const response = await downloadResumeGet(new Request("http://localhost/api/candidates/c1/resume"), {
+      params: Promise.resolve({ id: "c1" })
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/pdf");
+    expect(response.headers.get("Content-Disposition")).toContain("Alex-Smith.pdf");
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    expect(Array.from(buffer)).toEqual([1, 2, 3]);
+  });
+});


### PR DESCRIPTION
- Resolve resume object keys from local://, r2://, or public R2 base URLs.
- Add GET /api/candidates/[id]/resume for recruiter RBAC with streamed bytes.
- Surface Download original links in the analyses grid with light styling.
- Cover the route with Vitest using auth, DB, and storage mocks.

## Summary

- Describe what changed.
- Describe why the change was needed.

## Testing

- List the checks you ran.
- Note any checks you could not run.

## Documentation

- [ ] I updated `README.md` or `docs/*` when behavior, architecture, testing, or deployment expectations changed.
- [ ] I added or skipped a `docs/changelog.md` entry with a short reason.
- [ ] I organized any source Office docs under `docs/source/` and any committed exports under `docs/generated/`.
