### PR TITLE
Require auth for analyze and analyses API routes (Fixes #5)

### DIFF
--- a/app/api/analyses/route.ts
+++ b/app/api/analyses/route.ts
@@ -1,6 +1,16 @@
 import { NextResponse } from "next/server";
+import { canAccess, getSessionUser } from "@/lib/auth";
 import { listAnalyses } from "@/lib/db";
 
+function canViewAnalysisHistory(user: Awaited<ReturnType<typeof getSessionUser>>) {
+  return canAccess(user, "recruiter") || canAccess(user, "learning");
+}
+
 export async function GET() {
+  const user = await getSessionUser();
+  if (!canViewAnalysisHistory(user)) {
+    return NextResponse.json({ error: "Authentication required." }, { status: user ? 403 : 401 });
+  }
+
   return NextResponse.json({ analyses: await listAnalyses() });
 }

--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -1,9 +1,19 @@
 import { NextResponse } from "next/server";
+import { canAccess, getSessionUser } from "@/lib/auth";
 import { analyzeResume } from "@/lib/skillmatch";
 import { saveAnalysis } from "@/lib/db";
 import { analyzeRequestSchema, parseJsonRequestBody } from "@/lib/validation";
 
+function canRunResumeAnalysis(user: Awaited<ReturnType<typeof getSessionUser>>) {
+  return canAccess(user, "recruiter") || canAccess(user, "learning");
+}
+
 export async function POST(request: Request) {
+  const user = await getSessionUser();
+  if (!canRunResumeAnalysis(user)) {
+    return NextResponse.json({ error: "Authentication required." }, { status: user ? 403 : 401 });
+  }
+
   const { data, error } = await parseJsonRequestBody(analyzeRequestSchema, request);
   if (!data) {
     return NextResponse.json({ error }, { status: 400 });

--- a/tests/analyze-analyses-auth.test.ts
+++ b/tests/analyze-analyses-auth.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetSessionUser, mockListAnalyses, mockSaveAnalysis, mockAnalyzeResume } = vi.hoisted(() => ({
+  mockGetSessionUser: vi.fn(),
+  mockListAnalyses: vi.fn(),
+  mockSaveAnalysis: vi.fn(),
+  mockAnalyzeResume: vi.fn()
+}));
+
+vi.mock("@/lib/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/auth")>();
+  return {
+    ...actual,
+    getSessionUser: mockGetSessionUser
+  };
+});
+
+vi.mock("@/lib/db", () => ({
+  listAnalyses: mockListAnalyses,
+  saveAnalysis: mockSaveAnalysis
+}));
+
+vi.mock("@/lib/skillmatch", () => ({
+  analyzeResume: mockAnalyzeResume
+}));
+
+import { GET as analysesGet } from "@/app/api/analyses/route";
+import { POST as analyzePost } from "@/app/api/analyze/route";
+
+describe("analyze and analyses API authentication", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects unauthenticated GET /api/analyses with 401", async () => {
+    mockGetSessionUser.mockResolvedValue(null);
+    const response = await analysesGet();
+
+    expect(response.status).toBe(401);
+    expect(mockListAnalyses).not.toHaveBeenCalled();
+  });
+
+  it("rejects authenticated users without recruiter or L&D access for GET /api/analyses", async () => {
+    mockGetSessionUser.mockResolvedValue({
+      name: "Pat",
+      email: "pat@skillmatch.demo",
+      role: "employee"
+    });
+    const response = await analysesGet();
+
+    expect(response.status).toBe(403);
+    expect(mockListAnalyses).not.toHaveBeenCalled();
+  });
+
+  it("allows recruiters to list analyses", async () => {
+    mockGetSessionUser.mockResolvedValue({
+      name: "Recruiter",
+      email: "recruiter@skillmatch.demo",
+      role: "recruiter"
+    });
+    mockListAnalyses.mockResolvedValue([]);
+
+    const response = await analysesGet();
+    expect(response.status).toBe(200);
+    expect(mockListAnalyses).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects unauthenticated POST /api/analyze with 401", async () => {
+    mockGetSessionUser.mockResolvedValue(null);
+    const response = await analyzePost(
+      new Request("http://localhost/api/analyze", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          employeeName: "Demo",
+          resumeText: "x".repeat(30),
+          roleId: "sde-i"
+        })
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expect(mockAnalyzeResume).not.toHaveBeenCalled();
+    expect(mockSaveAnalysis).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
- Gate POST /api/analyze and GET /api/analyses behind session and recruiter or L&D RBAC (403 for other authenticated roles).
- Add Vitest coverage for 401/403 and successful recruiter access.

## Summary

- Describe what changed.
- Describe why the change was needed.

## Testing

- List the checks you ran.
- Note any checks you could not run.

## Documentation

- [ ] I updated `README.md` or `docs/*` when behavior, architecture, testing, or deployment expectations changed.
- [ ] I added or skipped a `docs/changelog.md` entry with a short reason.
- [ ] I organized any source Office docs under `docs/source/` and any committed exports under `docs/generated/`.
