### PR TITLE
feat: optional OpenAI resume narrative on upload

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,9 +15,10 @@ R2_SECRET_ACCESS_KEY=""
 R2_BUCKET=""
 R2_PUBLIC_BASE_URL=""
 
-# Optional: OpenAI-compatible chat API for structured resume narrative on upload (bias-masked text only).
-# Without this, heuristic skill matching still runs; the dashboard shows a short note instead.
-OPENAI_API_KEY=""
-# RESUME_AI_API_KEY=""
-# RESUME_AI_MODEL="gpt-4o-mini"
-# OPENAI_BASE_URL="https://api.openai.com/v1"
+# Optional: Google Gemini (AI Studio / Generative Language API) for structured resume narrative on upload
+# (bias-masked text only). Without this, heuristic skill matching still runs; the dashboard shows a short note.
+GEMINI_API_KEY=""
+# GOOGLE_API_KEY=""  # alias for GEMINI_API_KEY
+# GEMINI_MODEL="gemini-2.0-flash"
+# GEMINI_BASE_URL="https://generativelanguage.googleapis.com/v1beta"
+# RESUME_AI_API_KEY=""  # legacy alias for the same key

--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,10 @@ R2_ACCESS_KEY_ID=""
 R2_SECRET_ACCESS_KEY=""
 R2_BUCKET=""
 R2_PUBLIC_BASE_URL=""
+
+# Optional: OpenAI-compatible chat API for structured resume narrative on upload (bias-masked text only).
+# Without this, heuristic skill matching still runs; the dashboard shows a short note instead.
+OPENAI_API_KEY=""
+# RESUME_AI_API_KEY=""
+# RESUME_AI_MODEL="gpt-4o-mini"
+# OPENAI_BASE_URL="https://api.openai.com/v1"

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getSessionUser } from "@/lib/auth";
 import { saveAnalysis, saveCandidateBatch } from "@/lib/db";
 import { extractResumeText } from "@/lib/resume-parser";
+import { generateResumeAiInsight, getResumeAiInsightConfig } from "@/lib/resume-ai-insight";
 import { analyzeCandidateResume, type CandidateAnalysis } from "@/lib/skillmatch";
 import { storeResumeFile } from "@/lib/storage";
 
@@ -70,6 +71,22 @@ export async function POST(request: Request) {
         fileName: file.name,
         error: error instanceof Error ? error.message : "Unknown parsing failure"
       });
+    }
+  }
+
+  const aiConfig = getResumeAiInsightConfig();
+  if (aiConfig) {
+    for (const { candidate } of uploadOutputs) {
+      try {
+        candidate.aiInsight = await generateResumeAiInsight({
+          config: aiConfig,
+          maskedResumeText: candidate.structured.biasMaskedText,
+          topRoleTitles: candidate.topPositions.slice(0, 4).map((position) => position.role.title),
+          candidateLabel: candidate.candidateName
+        });
+      } catch {
+        candidate.aiInsight = null;
+      }
     }
   }
 

--- a/app/dashboard.tsx
+++ b/app/dashboard.tsx
@@ -913,8 +913,8 @@ function AiInsightPanel({ insight }: { insight: CandidateAnalysis["aiInsight"] }
         </div>
       ) : (
         <p className="list-placeholder">
-          Configure <code>OPENAI_API_KEY</code> (or <code>RESUME_AI_API_KEY</code>) on the server to generate a structured
-          narrative after each upload. Skill matching above still runs without it.
+          Configure <code>GEMINI_API_KEY</code> (Google AI Studio) on the server to generate a structured narrative after
+          each upload. Skill matching above still runs without it.
         </p>
       )}
     </section>

--- a/app/dashboard.tsx
+++ b/app/dashboard.tsx
@@ -18,6 +18,7 @@ import {
   Settings,
   ShieldCheck,
   SlidersHorizontal,
+  Sparkles,
   Target,
   Trash2,
   UploadCloud,
@@ -445,6 +446,7 @@ export default function Dashboard({ user }: { user: SessionUser }) {
                   }}
                 />
                 <RecommendationPanel candidate={selectedCandidate} />
+                <AiInsightPanel insight={selectedCandidate?.aiInsight ?? null} />
                 <RecentCandidates candidates={candidates} onSelect={setSelectedCandidateId} />
               </aside>
             </section>
@@ -858,6 +860,62 @@ function SavedRoleProgress({
         </div>
       ) : (
         <EmptyPanel title="No saved target roles" text="Save a role from the dashboard to start tracking employee progress." />
+      )}
+    </section>
+  );
+}
+
+function AiInsightPanel({ insight }: { insight: CandidateAnalysis["aiInsight"] }) {
+  return (
+    <section className="concept-panel ai-insight-panel">
+      <div className="panel-heading">
+        <h2>
+          <Sparkles aria-hidden="true" className="inline-icon" />
+          AI resume review
+        </h2>
+        <span>Advisory</span>
+      </div>
+      {insight ? (
+        <div className="ai-insight-body">
+          <p className="ai-insight-summary">{insight.summary}</p>
+          <div className="ai-insight-columns">
+            <div>
+              <h3>Strengths</h3>
+              <ul>
+                {insight.strengths.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <h3>Development areas</h3>
+              <ul>
+                {insight.developmentAreas.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+          <div>
+            <h3>Role fit</h3>
+            <p>{insight.roleFitNotes}</p>
+          </div>
+          {insight.followUpQuestions.length ? (
+            <div>
+              <h3>Follow-up questions</h3>
+              <ul className="follow-up-list">
+                {insight.followUpQuestions.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+      ) : (
+        <p className="list-placeholder">
+          Configure <code>OPENAI_API_KEY</code> (or <code>RESUME_AI_API_KEY</code>) on the server to generate a structured
+          narrative after each upload. Skill matching above still runs without it.
+        </p>
       )}
     </section>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -559,6 +559,58 @@ input:focus-visible {
   font-weight: 600;
 }
 
+.ai-insight-panel .panel-heading h2 {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.inline-icon {
+  width: 16px;
+  height: 16px;
+  color: var(--brand-dark);
+  flex-shrink: 0;
+}
+
+.ai-insight-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  font-size: 13px;
+  color: var(--ink);
+  line-height: 1.45;
+}
+
+.ai-insight-summary {
+  margin: 0;
+  color: var(--muted);
+}
+
+.ai-insight-columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+@media (max-width: 1100px) {
+  .ai-insight-columns {
+    grid-template-columns: 1fr;
+  }
+}
+
+.ai-insight-body ul {
+  margin: 6px 0 0;
+  padding-left: 18px;
+}
+
+.ai-insight-body li {
+  margin-bottom: 4px;
+}
+
+.follow-up-list {
+  list-style: disc;
+}
+
 /* ─── Upload panel ───────────────────────────────────────────── */
 
 .drop-zone {

--- a/db/migrations/0003_candidate_ai_insight.sql
+++ b/db/migrations/0003_candidate_ai_insight.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "candidate_recommendations" ADD COLUMN "ai_insight" jsonb;

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1777680000000,
       "tag": "0002_saved_target_roles",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1778000000000,
+      "tag": "0003_candidate_ai_insight",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,5 +1,6 @@
 import { sql } from "drizzle-orm";
 import { bigserial, check, index, integer, jsonb, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import type { ResumeAiInsight } from "@/lib/resume-ai-insight";
 
 export const users = pgTable(
   "users",
@@ -57,6 +58,7 @@ export const candidateRecommendations = pgTable(
     storageUrl: text("storage_url").notNull(),
     structuredResume: jsonb("structured_resume").notNull(),
     topPositions: jsonb("top_positions").notNull(),
+    aiInsight: jsonb("ai_insight").$type<ResumeAiInsight | null>(),
     bestRoleTitle: text("best_role_title").notNull(),
     bestScore: integer("best_score").notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow()

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -194,6 +194,7 @@ export async function saveCandidateBatch(input: {
       storageUrl: candidate.storageUrl,
       structuredResume: candidate.structured,
       topPositions: candidate.topPositions,
+      aiInsight: candidate.aiInsight,
       bestRoleTitle: best?.role.title ?? "No match",
       bestScore: best?.score ?? 0
     });
@@ -223,6 +224,7 @@ export async function listCandidateRecommendations(filters: CandidateRecommendat
       storageUrl: candidateRecommendations.storageUrl,
       structured: candidateRecommendations.structuredResume,
       topPositions: candidateRecommendations.topPositions,
+      aiInsight: candidateRecommendations.aiInsight,
       createdAt: candidateRecommendations.createdAt
     })
     .from(candidateRecommendations)
@@ -236,6 +238,7 @@ export async function listCandidateRecommendations(filters: CandidateRecommendat
     storageUrl: row.storageUrl,
     structured: row.structured as CandidateAnalysis["structured"],
     topPositions: row.topPositions as CandidateAnalysis["topPositions"],
+    aiInsight: (row.aiInsight ?? null) as CandidateAnalysis["aiInsight"],
     createdAt: row.createdAt.toISOString()
   })) as CandidateAnalysis[];
 

--- a/lib/resume-ai-insight.ts
+++ b/lib/resume-ai-insight.ts
@@ -1,0 +1,109 @@
+import { z } from "zod";
+
+const resumeAiInsightSchema = z.object({
+  summary: z.string().max(2800),
+  strengths: z.array(z.string().max(600)).max(12),
+  developmentAreas: z.array(z.string().max(600)).max(12),
+  roleFitNotes: z.string().max(2000),
+  followUpQuestions: z.array(z.string().max(500)).max(8)
+});
+
+export type ResumeAiInsight = z.infer<typeof resumeAiInsightSchema>;
+
+export type ResumeAiInsightConfig = {
+  apiKey: string;
+  model: string;
+  baseUrl: string;
+};
+
+const defaultBaseUrl = "https://api.openai.com/v1";
+
+export function getResumeAiInsightConfig(env: NodeJS.ProcessEnv = process.env): ResumeAiInsightConfig | null {
+  const apiKey = env.OPENAI_API_KEY?.trim() || env.RESUME_AI_API_KEY?.trim();
+  if (!apiKey) {
+    return null;
+  }
+
+  const model = env.RESUME_AI_MODEL?.trim() || "gpt-4o-mini";
+  const baseUrl = (
+    env.OPENAI_BASE_URL?.trim() ||
+    env.RESUME_AI_BASE_URL?.trim() ||
+    defaultBaseUrl
+  ).replace(/\/$/, "");
+
+  return { apiKey, model, baseUrl };
+}
+
+function extractJsonObject(raw: string): unknown {
+  const trimmed = raw.trim();
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    const start = trimmed.indexOf("{");
+    const end = trimmed.lastIndexOf("}");
+    if (start >= 0 && end > start) {
+      return JSON.parse(trimmed.slice(start, end + 1));
+    }
+    throw new Error("No JSON object in model response");
+  }
+}
+
+export async function generateResumeAiInsight(input: {
+  config: ResumeAiInsightConfig;
+  maskedResumeText: string;
+  topRoleTitles: string[];
+  candidateLabel: string;
+}): Promise<ResumeAiInsight | null> {
+  const trimmedResume = input.maskedResumeText.slice(0, 14_000);
+  const system = [
+    "You are a senior technical recruiter assisting with structured resume review.",
+    "The resume text may have demographics and contact details masked with tokens like [email masked].",
+    "Respond with a single JSON object only (no markdown) using exactly these keys:",
+    'summary (string), strengths (string[]), developmentAreas (string[]), roleFitNotes (string), followUpQuestions (string[]).',
+    "Be specific and professional. Flag possible credential inflation only when justified by the text.",
+    "Do not invent employers, degrees, or metrics that are not supported by the resume."
+  ].join(" ");
+
+  const userPayload = JSON.stringify({
+    candidateLabel: input.candidateLabel,
+    topRankedRoles: input.topRoleTitles,
+    resumeText: trimmedResume
+  });
+
+  const response = await fetch(`${input.config.baseUrl}/chat/completions`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${input.config.apiKey}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      model: input.config.model,
+      temperature: 0.25,
+      max_tokens: 1400,
+      response_format: { type: "json_object" },
+      messages: [
+        { role: "system", content: system },
+        { role: "user", content: userPayload }
+      ]
+    })
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const payload = (await response.json()) as {
+    choices?: Array<{ message?: { content?: string } }>;
+  };
+  const content = payload.choices?.[0]?.message?.content;
+  if (typeof content !== "string") {
+    return null;
+  }
+
+  try {
+    const parsed = resumeAiInsightSchema.safeParse(extractJsonObject(content));
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}

--- a/lib/resume-ai-insight.ts
+++ b/lib/resume-ai-insight.ts
@@ -16,20 +16,23 @@ export type ResumeAiInsightConfig = {
   baseUrl: string;
 };
 
-const defaultBaseUrl = "https://api.openai.com/v1";
+const defaultGeminiBaseUrl = "https://generativelanguage.googleapis.com/v1beta";
 
 export function getResumeAiInsightConfig(env: NodeJS.ProcessEnv = process.env): ResumeAiInsightConfig | null {
-  const apiKey = env.OPENAI_API_KEY?.trim() || env.RESUME_AI_API_KEY?.trim();
+  const apiKey =
+    env.GEMINI_API_KEY?.trim() ||
+    env.GOOGLE_API_KEY?.trim() ||
+    env.RESUME_AI_API_KEY?.trim();
   if (!apiKey) {
     return null;
   }
 
-  const model = env.RESUME_AI_MODEL?.trim() || "gpt-4o-mini";
-  const baseUrl = (
-    env.OPENAI_BASE_URL?.trim() ||
-    env.RESUME_AI_BASE_URL?.trim() ||
-    defaultBaseUrl
-  ).replace(/\/$/, "");
+  const model =
+    env.GEMINI_MODEL?.trim() ||
+    env.RESUME_AI_MODEL?.trim() ||
+    "gemini-2.0-flash";
+
+  const baseUrl = (env.GEMINI_BASE_URL?.trim() || defaultGeminiBaseUrl).replace(/\/$/, "");
 
   return { apiKey, model, baseUrl };
 }
@@ -47,6 +50,12 @@ function extractJsonObject(raw: string): unknown {
     throw new Error("No JSON object in model response");
   }
 }
+
+type GeminiGenerateContentResponse = {
+  candidates?: Array<{
+    content?: { parts?: Array<{ text?: string }> };
+  }>;
+};
 
 export async function generateResumeAiInsight(input: {
   config: ResumeAiInsightConfig;
@@ -70,21 +79,20 @@ export async function generateResumeAiInsight(input: {
     resumeText: trimmedResume
   });
 
-  const response = await fetch(`${input.config.baseUrl}/chat/completions`, {
+  const endpoint = `${input.config.baseUrl}/models/${encodeURIComponent(input.config.model)}:generateContent`;
+  const url = `${endpoint}?key=${encodeURIComponent(input.config.apiKey)}`;
+
+  const response = await fetch(url, {
     method: "POST",
-    headers: {
-      Authorization: `Bearer ${input.config.apiKey}`,
-      "Content-Type": "application/json"
-    },
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
-      model: input.config.model,
-      temperature: 0.25,
-      max_tokens: 1400,
-      response_format: { type: "json_object" },
-      messages: [
-        { role: "system", content: system },
-        { role: "user", content: userPayload }
-      ]
+      systemInstruction: { parts: [{ text: system }] },
+      contents: [{ role: "user", parts: [{ text: userPayload }] }],
+      generationConfig: {
+        temperature: 0.25,
+        maxOutputTokens: 2048,
+        responseMimeType: "application/json"
+      }
     })
   });
 
@@ -92,10 +100,8 @@ export async function generateResumeAiInsight(input: {
     return null;
   }
 
-  const payload = (await response.json()) as {
-    choices?: Array<{ message?: { content?: string } }>;
-  };
-  const content = payload.choices?.[0]?.message?.content;
+  const payload = (await response.json()) as GeminiGenerateContentResponse;
+  const content = payload.candidates?.[0]?.content?.parts?.[0]?.text;
   if (typeof content !== "string") {
     return null;
   }

--- a/lib/skillmatch.ts
+++ b/lib/skillmatch.ts
@@ -1,4 +1,5 @@
 import { matchingConfig, roles, type RoleRequirement } from "./seed-data";
+import type { ResumeAiInsight } from "./resume-ai-insight";
 import { isKnownRoleId } from "./validation";
 
 type SkillSource = "required" | "preferred";
@@ -64,6 +65,7 @@ export type CandidateAnalysis = {
   storageUrl: string;
   topPositions: CandidatePositionRecommendation[];
   structured: StructuredResume;
+  aiInsight: ResumeAiInsight | null;
   createdAt: string;
 };
 
@@ -325,6 +327,7 @@ export function analyzeCandidateResume(input: {
     storageUrl: input.storageUrl,
     topPositions,
     structured: topPositions[0]?.structured ?? extractStructuredResume(input.resumeText),
+    aiInsight: null,
     createdAt: new Date().toISOString()
   };
 }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/tests/resume-ai-insight.test.ts
+++ b/tests/resume-ai-insight.test.ts
@@ -6,33 +6,42 @@ describe("resume AI insight", () => {
     expect(getResumeAiInsightConfig({})).toBeNull();
   });
 
-  it("reads configuration from OPENAI_API_KEY", () => {
+  it("reads configuration from GEMINI_API_KEY", () => {
     expect(
       getResumeAiInsightConfig({
-        OPENAI_API_KEY: "test-key"
+        GEMINI_API_KEY: "test-key"
       })
     ).toEqual({
       apiKey: "test-key",
-      model: "gpt-4o-mini",
-      baseUrl: "https://api.openai.com/v1"
+      model: "gemini-2.0-flash",
+      baseUrl: "https://generativelanguage.googleapis.com/v1beta"
     });
   });
 
-  it("falls back to RESUME_AI_API_KEY", () => {
+  it("prefers GEMINI_API_KEY over GOOGLE_API_KEY", () => {
     expect(
       getResumeAiInsightConfig({
-        RESUME_AI_API_KEY: "other",
-        RESUME_AI_MODEL: "custom-model",
-        RESUME_AI_BASE_URL: "https://example.com/v1/"
+        GEMINI_API_KEY: "gemini-first",
+        GOOGLE_API_KEY: "google-second"
+      })
+    ).toMatchObject({ apiKey: "gemini-first" });
+  });
+
+  it("falls back to RESUME_AI_API_KEY and RESUME_AI_MODEL", () => {
+    expect(
+      getResumeAiInsightConfig({
+        RESUME_AI_API_KEY: "legacy",
+        RESUME_AI_MODEL: "gemini-1.5-flash",
+        GEMINI_BASE_URL: "https://example.com/v1beta/"
       })
     ).toEqual({
-      apiKey: "other",
-      model: "custom-model",
-      baseUrl: "https://example.com/v1"
+      apiKey: "legacy",
+      model: "gemini-1.5-flash",
+      baseUrl: "https://example.com/v1beta"
     });
   });
 
-  it("parses a successful chat completion into structured insight", async () => {
+  it("parses a successful Gemini generateContent response into structured insight", async () => {
     const payload = {
       summary: "Strong backend engineer.",
       strengths: ["Distributed systems"],
@@ -44,7 +53,7 @@ describe("resume AI insight", () => {
     const mockFetch = vi.fn(async () => {
       return new Response(
         JSON.stringify({
-          choices: [{ message: { content: JSON.stringify(payload) } }]
+          candidates: [{ content: { parts: [{ text: JSON.stringify(payload) }] } }]
         }),
         { status: 200 }
       );
@@ -52,7 +61,11 @@ describe("resume AI insight", () => {
     vi.stubGlobal("fetch", mockFetch);
 
     const result = await generateResumeAiInsight({
-      config: { apiKey: "k", model: "gpt-4o-mini", baseUrl: "https://api.openai.com/v1" },
+      config: {
+        apiKey: "k",
+        model: "gemini-2.0-flash",
+        baseUrl: "https://generativelanguage.googleapis.com/v1beta"
+      },
       maskedResumeText: "Engineer with Java and AWS.",
       topRoleTitles: ["Software Dev Engineer II"],
       candidateLabel: "Jamie"
@@ -62,13 +75,21 @@ describe("resume AI insight", () => {
 
     expect(result).toEqual(payload);
     expect(mockFetch).toHaveBeenCalledTimes(1);
+    const callUrl = String(mockFetch.mock.calls[0]?.[0]);
+    expect(callUrl).toContain("/models/gemini-2.0-flash:generateContent");
+    expect(callUrl).toContain("key=k");
   });
 
   it("returns null on HTTP errors", async () => {
-    vi.stubGlobal("fetch", vi.fn(async () => new Response("err", { status: 500 })));
+    const mockFetch = vi.fn(async () => new Response("err", { status: 500 }));
+    vi.stubGlobal("fetch", mockFetch);
 
     const result = await generateResumeAiInsight({
-      config: { apiKey: "k", model: "m", baseUrl: "https://api.openai.com/v1" },
+      config: {
+        apiKey: "k",
+        model: "m",
+        baseUrl: "https://generativelanguage.googleapis.com/v1beta"
+      },
       maskedResumeText: "x".repeat(40),
       topRoleTitles: ["Role A"],
       candidateLabel: "x"

--- a/tests/resume-ai-insight.test.ts
+++ b/tests/resume-ai-insight.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import { generateResumeAiInsight, getResumeAiInsightConfig } from "@/lib/resume-ai-insight";
+
+describe("resume AI insight", () => {
+  it("returns null when no API key is configured", () => {
+    expect(getResumeAiInsightConfig({})).toBeNull();
+  });
+
+  it("reads configuration from OPENAI_API_KEY", () => {
+    expect(
+      getResumeAiInsightConfig({
+        OPENAI_API_KEY: "test-key"
+      })
+    ).toEqual({
+      apiKey: "test-key",
+      model: "gpt-4o-mini",
+      baseUrl: "https://api.openai.com/v1"
+    });
+  });
+
+  it("falls back to RESUME_AI_API_KEY", () => {
+    expect(
+      getResumeAiInsightConfig({
+        RESUME_AI_API_KEY: "other",
+        RESUME_AI_MODEL: "custom-model",
+        RESUME_AI_BASE_URL: "https://example.com/v1/"
+      })
+    ).toEqual({
+      apiKey: "other",
+      model: "custom-model",
+      baseUrl: "https://example.com/v1"
+    });
+  });
+
+  it("parses a successful chat completion into structured insight", async () => {
+    const payload = {
+      summary: "Strong backend engineer.",
+      strengths: ["Distributed systems"],
+      developmentAreas: ["Front-end depth"],
+      roleFitNotes: "Fits SDE II well.",
+      followUpQuestions: ["Tell me about team size."]
+    };
+
+    const mockFetch = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { content: JSON.stringify(payload) } }]
+        }),
+        { status: 200 }
+      );
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await generateResumeAiInsight({
+      config: { apiKey: "k", model: "gpt-4o-mini", baseUrl: "https://api.openai.com/v1" },
+      maskedResumeText: "Engineer with Java and AWS.",
+      topRoleTitles: ["Software Dev Engineer II"],
+      candidateLabel: "Jamie"
+    });
+
+    vi.unstubAllGlobals();
+
+    expect(result).toEqual(payload);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null on HTTP errors", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("err", { status: 500 })));
+
+    const result = await generateResumeAiInsight({
+      config: { apiKey: "k", model: "m", baseUrl: "https://api.openai.com/v1" },
+      maskedResumeText: "x".repeat(40),
+      topRoleTitles: ["Role A"],
+      candidateLabel: "x"
+    });
+
+    vi.unstubAllGlobals();
+
+    expect(result).toBeNull();
+  });
+});

--- a/tests/skillmatch.test.ts
+++ b/tests/skillmatch.test.ts
@@ -97,6 +97,7 @@ describe("skill matching engine", () => {
     });
 
     expect(analysis.candidateName).toBe("Alex Smith");
+    expect(analysis.aiInsight).toBeNull();
     expect(analysis.structured.certifications.join(" ")).toMatch(/AWS Certified|Cloud Practitioner/i);
     expect(analysis.structured.location).toBeNull();
     expect(maskDemographicSignals(analysis.structured.biasMaskedText)).toContain("[email masked]");


### PR DESCRIPTION
- Add generateResumeAiInsight using masked resume text and top role titles
- Extend CandidateAnalysis with aiInsight; persist to candidate_recommendations
- Dashboard panel for structured AI review with graceful empty state
- Migration 0003 and unit tests for insight helper

Refs #38, #39, #47

## Summary

- Describe what changed.
- Describe why the change was needed.

## Testing

- List the checks you ran.
- Note any checks you could not run.

## Documentation

- [ ] I updated `README.md` or `docs/*` when behavior, architecture, testing, or deployment expectations changed.
- [ ] I added or skipped a `docs/changelog.md` entry with a short reason.
- [ ] I organized any source Office docs under `docs/source/` and any committed exports under `docs/generated/`.
