### PR TITLE
fix: make database setup repeatable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,11 @@ The available variables are listed in `.env.example`.
 
 Persistent storage is modeled with Drizzle ORM in `db/schema.ts` and mirrored by the SQL bootstrap file in `db/schema.sql`:
 
+- `users`
 - `analyses`
 - `audit_events`
 - `candidate_recommendations`
+- `saved_target_roles`
 
 Apply the schema before running against a real `DATABASE_URL`. To generate Drizzle migrations from the typed schema, run:
 
@@ -57,13 +59,15 @@ Apply the schema before running against a real `DATABASE_URL`. To generate Drizz
 npm run db:generate
 ```
 
-Then apply generated migrations with:
+Then apply the repeatable setup step with:
 
 ```powershell
-npm run db:migrate
+npm run db:setup
 ```
 
-The migration script uses `DATABASE_URL` from the current shell or `.env`.
+`npm run db:setup` and `npm run db:migrate` both run the same idempotent migration entrypoint. It resolves `DATABASE_URL` from the current shell first, then `.env.local`, then `.env`, which matches the local setup flow above.
+
+If the database is already current, rerunning the command is safe. If no `DATABASE_URL` is configured, the script fails early with a clear message instead of silently falling back to in-memory mode.
 
 For the existing bootstrap SQL, you can still run:
 
@@ -78,6 +82,7 @@ You can also paste the contents of `db/schema.sql` into the Neon SQL editor for 
 The app is designed to run without external services during local development:
 
 - If `DATABASE_URL` is not set, `lib/db.ts` stores analyses, candidate recommendations, and audit events in memory. Data resets when the dev server restarts.
+- `GET /api/health` reports whether the app is using memory fallback or a configured Postgres database, and returns `503` when a database is configured but the expected tables have not been created yet.
 - Signup requires `DATABASE_URL`; created accounts are stored in the `users` table. When no database is configured, sign in with demo or `AUTH_USERS_JSON` users instead.
 - If any required R2 setting is missing, `lib/storage.ts` stores uploaded resume bytes in an in-memory map and returns `local://...` URLs. Those files are not persisted across server restarts.
 - If `AUTH_USERS_JSON` is not set, demo users are loaded from `lib/auth-model.ts`.

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from "next/server";
+import { neon } from "@neondatabase/serverless";
+import { getDatabaseConfig } from "@/lib/env";
+
+const requiredTables = [
+  "users",
+  "analyses",
+  "audit_events",
+  "candidate_recommendations",
+  "saved_target_roles",
+  "__drizzle_migrations"
+] as const;
+
+export const dynamic = "force-dynamic";
+
+function createMemoryHealthResponse() {
+  return NextResponse.json({
+    status: "ok",
+    database: {
+      configured: false,
+      mode: "memory",
+      schemaReady: false,
+      missingTables: requiredTables.filter((table) => table !== "__drizzle_migrations")
+    }
+  });
+}
+
+export async function GET() {
+  const { url } = getDatabaseConfig();
+
+  if (!url) {
+    return createMemoryHealthResponse();
+  }
+
+  try {
+    const sql = neon(url);
+    const rows = await sql`
+      select table_name
+      from information_schema.tables
+      where table_schema = 'public'
+    `;
+
+    const existingTables = new Set(
+      rows
+        .map((row) => String(row.table_name))
+        .filter((tableName) => requiredTables.includes(tableName as (typeof requiredTables)[number]))
+    );
+    const missingTables = requiredTables.filter((table) => !existingTables.has(table));
+    const schemaReady = missingTables.length === 0;
+
+    return NextResponse.json(
+      {
+        status: schemaReady ? "ok" : "degraded",
+        database: {
+          configured: true,
+          mode: "postgres",
+          schemaReady,
+          missingTables
+        }
+      },
+      { status: schemaReady ? 200 : 503 }
+    );
+  } catch (error) {
+    return NextResponse.json(
+      {
+        status: "degraded",
+        database: {
+          configured: true,
+          mode: "postgres",
+          schemaReady: false,
+          missingTables: requiredTables
+        },
+        error: error instanceof Error ? error.message : "Database health check failed."
+      },
+      { status: 503 }
+    );
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "db:generate": "drizzle-kit generate",
+    "db:setup": "node scripts/migrate.mjs",
     "db:migrate": "node scripts/migrate.mjs",
     "test:e2e": "playwright test"
   },

--- a/scripts/migrate.mjs
+++ b/scripts/migrate.mjs
@@ -1,26 +1,75 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { neon } from "@neondatabase/serverless";
 import { drizzle } from "drizzle-orm/neon-http";
 import { migrate } from "drizzle-orm/neon-http/migrator";
 
-function readDatabaseUrl() {
-  if (process.env.DATABASE_URL) {
-    return process.env.DATABASE_URL;
-  }
+const envFiles = [".env.local", ".env"];
+const migrationsFolder = "./db/migrations";
 
-  try {
-    const env = readFileSync(".env", "utf8");
-    const match = env.match(/^DATABASE_URL=(.*)$/m);
-    return match?.[1]?.trim().replace(/^"|"$/g, "");
-  } catch {
+function stripWrappingQuotes(value) {
+  return value.replace(/^['"]|['"]$/g, "");
+}
+
+function readEnvFileValue(filePath, key) {
+  if (!existsSync(filePath)) {
     return undefined;
   }
+
+  const contents = readFileSync(filePath, "utf8");
+  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = contents.match(new RegExp(`^${escapedKey}\\s*=\\s*(.*)$`, "m"));
+  const rawValue = match?.[1]?.trim();
+
+  return rawValue ? stripWrappingQuotes(rawValue) : undefined;
 }
 
-const databaseUrl = readDatabaseUrl();
-if (!databaseUrl) {
-  throw new Error("DATABASE_URL is required to run database migrations.");
+export function readDatabaseUrl(options = {}) {
+  const env = options.env ?? process.env;
+  const cwd = options.cwd ?? process.cwd();
+  const explicitValue = env.DATABASE_URL?.trim();
+
+  if (explicitValue) {
+    return explicitValue;
+  }
+
+  for (const fileName of envFiles) {
+    const value = readEnvFileValue(path.join(cwd, fileName), "DATABASE_URL");
+    if (value) {
+      return value;
+    }
+  }
+
+  return undefined;
 }
 
-await migrate(drizzle(neon(databaseUrl)), { migrationsFolder: "./db/migrations" });
-console.log("Database migrations applied.");
+export async function runMigrations(options = {}) {
+  const databaseUrl = readDatabaseUrl(options);
+
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is required to run database setup. Checked process.env, .env.local, and .env.");
+  }
+
+  await migrate(drizzle(neon(databaseUrl)), { migrationsFolder });
+
+  return {
+    databaseUrl,
+    migrationsFolder
+  };
+}
+
+async function main() {
+  const result = await runMigrations();
+  console.log(`Database setup complete via ${result.migrationsFolder}.`);
+}
+
+const isDirectRun =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+
+if (isDirectRun) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/tests/migrate.test.ts
+++ b/tests/migrate.test.ts
@@ -6,8 +6,8 @@ import { afterEach, describe, expect, it } from "vitest";
 const tempDirectories: string[] = [];
 
 async function loadReadDatabaseUrl() {
-  const module = await import("../scripts/migrate.mjs");
-  return module.readDatabaseUrl as (options?: {
+  const migrateModule = await import("../scripts/migrate.mjs");
+  return migrateModule.readDatabaseUrl as (options?: {
     env?: NodeJS.ProcessEnv;
     cwd?: string;
   }) => string | undefined;

--- a/tests/migrate.test.ts
+++ b/tests/migrate.test.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const tempDirectories: string[] = [];
+
+async function loadReadDatabaseUrl() {
+  const module = await import("../scripts/migrate.mjs");
+  return module.readDatabaseUrl as (options?: {
+    env?: NodeJS.ProcessEnv;
+    cwd?: string;
+  }) => string | undefined;
+}
+
+function createTempDir() {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "skillmatch-migrate-"));
+  tempDirectories.push(directory);
+  return directory;
+}
+
+afterEach(() => {
+  while (tempDirectories.length > 0) {
+    const directory = tempDirectories.pop();
+    if (directory) {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("readDatabaseUrl", () => {
+  it("prefers DATABASE_URL from the process environment", async () => {
+    const readDatabaseUrl = await loadReadDatabaseUrl();
+    const cwd = createTempDir();
+
+    fs.writeFileSync(path.join(cwd, ".env.local"), "DATABASE_URL=postgres://from-local-file");
+    expect(readDatabaseUrl({ cwd, env: { DATABASE_URL: "postgres://from-env" } })).toBe("postgres://from-env");
+  });
+
+  it("falls back to .env.local before .env", async () => {
+    const readDatabaseUrl = await loadReadDatabaseUrl();
+    const cwd = createTempDir();
+
+    fs.writeFileSync(path.join(cwd, ".env"), "DATABASE_URL=postgres://from-env-file");
+    fs.writeFileSync(path.join(cwd, ".env.local"), 'DATABASE_URL="postgres://from-local-file"');
+
+    expect(readDatabaseUrl({ cwd, env: {} })).toBe("postgres://from-local-file");
+  });
+
+  it("returns undefined when no database URL is configured", async () => {
+    const readDatabaseUrl = await loadReadDatabaseUrl();
+
+    expect(readDatabaseUrl({ cwd: createTempDir(), env: {} })).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What changed
- added a repeatable `db:setup` entrypoint that resolves `DATABASE_URL` from `process.env`, `.env.local`, then `.env`
- added `/api/health` to surface memory mode vs configured Postgres schema readiness
- documented the setup flow and added focused migration resolution tests

## Why
Issue #22 calls for a repeatable migration/setup command plus a clear signal when the database schema is missing.

## Testing
- local dependency install was blocked in this sandbox by network/permission restrictions, so lint/tests/build could not be executed here
- added Vitest coverage for migration config resolution order

Closes #22