### PR TITLE
feat: detect duplicate and clustered resume uploads

### DIFF
--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 import { getSessionUser } from "@/lib/auth";
-import { saveAnalysis, saveCandidateBatch } from "@/lib/db";
+import { buildCandidateDuplicateIdentity, saveAnalysis, saveCandidateBatch, type CandidateDuplicateWarning } from "@/lib/db";
 import { extractResumeText } from "@/lib/resume-parser";
-import { analyzeCandidateResume, type CandidateAnalysis } from "@/lib/skillmatch";
+import { analyzeCandidateResume, inferCandidateName, type CandidateAnalysis } from "@/lib/skillmatch";
 import { storeResumeFile } from "@/lib/storage";
 
 const maxFiles = 12;
@@ -35,8 +35,16 @@ export async function POST(request: Request) {
   }
 
   const candidates = [];
-  const uploadOutputs: { candidate: CandidateAnalysis; resumeText: string }[] = [];
+  const uploadOutputs: {
+    candidate: CandidateAnalysis;
+    resumeText: string;
+    duplicateKey: string;
+    clusterKey: string;
+  }[] = [];
   const failures = [];
+  const duplicates: CandidateDuplicateWarning[] = [];
+  const seenDuplicateKeys = new Set<string>();
+  const seenClusterKeys = new Set<string>();
 
   for (const file of files) {
     try {
@@ -53,6 +61,41 @@ export async function POST(request: Request) {
         throw new Error("Resume text could not be extracted.");
       }
 
+      const candidateName = inferCandidateName(file.name, parsed.text);
+      const { duplicateKey, clusterKey } = buildCandidateDuplicateIdentity({
+        candidateName,
+        fileName: file.name,
+        resumeText: parsed.text
+      });
+
+      if (seenDuplicateKeys.has(duplicateKey)) {
+        duplicates.push({
+          type: "exact_duplicate",
+          source: "upload_batch",
+          candidateName,
+          fileName: file.name,
+          duplicateKey,
+          clusterKey,
+          message: "Skipped duplicate resume upload in the same batch."
+        });
+        continue;
+      }
+
+      if (seenClusterKeys.has(clusterKey)) {
+        duplicates.push({
+          type: "candidate_cluster",
+          source: "upload_batch",
+          candidateName,
+          fileName: file.name,
+          duplicateKey,
+          clusterKey,
+          message: "Candidate is clustered with another resume in the same upload batch."
+        });
+      }
+
+      seenDuplicateKeys.add(duplicateKey);
+      seenClusterKeys.add(clusterKey);
+
       const stored = await storeResumeFile({
         fileName: file.name,
         contentType: file.type || "application/octet-stream",
@@ -64,7 +107,7 @@ export async function POST(request: Request) {
         storageUrl: stored.url
       });
       candidates.push(candidate);
-      uploadOutputs.push({ candidate, resumeText: parsed.text });
+      uploadOutputs.push({ candidate, resumeText: parsed.text, duplicateKey, clusterKey });
     } catch (error) {
       failures.push({
         fileName: file.name,
@@ -74,8 +117,15 @@ export async function POST(request: Request) {
   }
 
   if (candidates.length) {
-    await saveCandidateBatch({ actor: user.email, candidates });
+    const saved = await saveCandidateBatch({ actor: user.email, uploads: uploadOutputs });
+    const savedCandidateIds = new Set(saved.candidates.map((candidate) => candidate.id));
+    duplicates.push(...saved.duplicates);
+
     for (const { candidate, resumeText } of uploadOutputs) {
+      if (!savedCandidateIds.has(candidate.id)) {
+        continue;
+      }
+
       const best = candidate.topPositions[0];
       if (best) {
         await saveAnalysis({
@@ -86,7 +136,9 @@ export async function POST(request: Request) {
         });
       }
     }
+
+    return NextResponse.json({ candidates: saved.candidates, duplicates, failures });
   }
 
-  return NextResponse.json({ candidates, failures });
+  return NextResponse.json({ candidates, duplicates, failures });
 }

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -20,13 +20,81 @@ export type CandidateRecommendationFilters = {
   minYearsExperience?: number;
 };
 
+export type CandidateDuplicateWarning = {
+  type: "exact_duplicate" | "candidate_cluster";
+  source: "upload_batch" | "existing_records";
+  candidateName: string;
+  fileName: string;
+  duplicateKey: string;
+  clusterKey: string;
+  matchedCandidateId?: string;
+  matchedFileName?: string;
+  message: string;
+};
+
+export type CandidateUploadRecord = {
+  candidate: CandidateAnalysis;
+  resumeText: string;
+  duplicateKey: string;
+  clusterKey: string;
+};
+
 const memoryStore: AnalysisRecord[] = [];
 const memoryCandidates: CandidateAnalysis[] = [];
+const memoryCandidateUploads: CandidateUploadRecord[] = [];
 const memoryAuditEvents: AuditEvent[] = [];
 const memorySavedTargetRoles: SavedTargetRole[] = [];
 
 function normalizeFilterValue(value: string) {
   return value.trim().toLowerCase();
+}
+
+function normalizeDuplicateValue(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/\.[^.]+$/, "")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function hashDuplicateValue(value: string) {
+  let hash = 2166136261;
+
+  for (const char of value) {
+    hash ^= char.charCodeAt(0);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+export function buildCandidateDuplicateIdentity(input: {
+  candidateName: string;
+  fileName: string;
+  resumeText: string;
+}) {
+  const candidateKey = normalizeDuplicateValue(input.candidateName) || "candidate";
+  const fileKey = normalizeDuplicateValue(input.fileName) || "file";
+  const resumeKey = normalizeDuplicateValue(input.resumeText);
+  const duplicateKey = `${candidateKey}:${hashDuplicateValue(resumeKey)}`;
+  const clusterKey = `${candidateKey}:${fileKey}`;
+
+  return { duplicateKey, clusterKey };
+}
+
+function createDuplicateWarning(
+  input: Omit<CandidateDuplicateWarning, "message"> & {
+    message?: string;
+  }
+): CandidateDuplicateWarning {
+  return {
+    ...input,
+    message:
+      input.message ??
+      (input.type === "exact_duplicate"
+        ? "Skipped duplicate resume upload."
+        : "Uploaded candidate is clustered with an existing candidate record.")
+  };
 }
 
 export function filterCandidateRecommendations(
@@ -171,29 +239,171 @@ export async function appendAuditEvent(input: {
 
 export async function saveCandidateBatch(input: {
   actor: string;
-  candidates: CandidateAnalysis[];
+  uploads: CandidateUploadRecord[];
 }) {
   const db = getDatabase();
+  const seenDuplicateKeys = new Set<string>();
+  const savedUploads: CandidateUploadRecord[] = [];
+  const duplicates: CandidateDuplicateWarning[] = [];
 
   if (!db) {
-    memoryCandidates.unshift(...input.candidates);
+    for (const upload of input.uploads) {
+      const batchDuplicate = seenDuplicateKeys.has(upload.duplicateKey);
+      if (batchDuplicate) {
+        duplicates.push(
+          createDuplicateWarning({
+            type: "exact_duplicate",
+            source: "upload_batch",
+            candidateName: upload.candidate.candidateName,
+            fileName: upload.candidate.fileName,
+            duplicateKey: upload.duplicateKey,
+            clusterKey: upload.clusterKey
+          })
+        );
+        continue;
+      }
+
+      seenDuplicateKeys.add(upload.duplicateKey);
+
+      const existingDuplicate = memoryCandidateUploads.find((item) => item.duplicateKey === upload.duplicateKey);
+      if (existingDuplicate) {
+        duplicates.push(
+          createDuplicateWarning({
+            type: "exact_duplicate",
+            source: "existing_records",
+            candidateName: upload.candidate.candidateName,
+            fileName: upload.candidate.fileName,
+            duplicateKey: upload.duplicateKey,
+            clusterKey: upload.clusterKey,
+            matchedCandidateId: existingDuplicate.candidate.id,
+            matchedFileName: existingDuplicate.candidate.fileName
+          })
+        );
+        continue;
+      }
+
+      const existingCluster = memoryCandidateUploads.find((item) => item.clusterKey === upload.clusterKey);
+      if (existingCluster) {
+        duplicates.push(
+          createDuplicateWarning({
+            type: "candidate_cluster",
+            source: "existing_records",
+            candidateName: upload.candidate.candidateName,
+            fileName: upload.candidate.fileName,
+            duplicateKey: upload.duplicateKey,
+            clusterKey: upload.clusterKey,
+            matchedCandidateId: existingCluster.candidate.id,
+            matchedFileName: existingCluster.candidate.fileName
+          })
+        );
+      }
+
+      savedUploads.push(upload);
+    }
+
+    memoryCandidateUploads.unshift(...savedUploads);
+    memoryCandidates.unshift(...savedUploads.map((upload) => upload.candidate));
     await appendAuditEvent({
       actor: input.actor,
       action: "recommendation_generation",
-      details: { count: input.candidates.length, mode: "local_memory" }
+      details: { count: savedUploads.length, duplicates: duplicates.length, mode: "local_memory" }
     });
-    return input.candidates;
+    return {
+      candidates: savedUploads.map((upload) => upload.candidate),
+      duplicates
+    };
   }
 
-  for (const candidate of input.candidates) {
-    const best = candidate.topPositions[0];
+  for (const upload of input.uploads) {
+    const batchDuplicate = seenDuplicateKeys.has(upload.duplicateKey);
+    if (batchDuplicate) {
+      duplicates.push(
+        createDuplicateWarning({
+          type: "exact_duplicate",
+          source: "upload_batch",
+          candidateName: upload.candidate.candidateName,
+          fileName: upload.candidate.fileName,
+          duplicateKey: upload.duplicateKey,
+          clusterKey: upload.clusterKey
+        })
+      );
+      continue;
+    }
+
+    seenDuplicateKeys.add(upload.duplicateKey);
+
+    const existingAnalyses = await db
+      .select({
+        id: analyses.id,
+        employeeName: analyses.employeeName,
+        resumeText: analyses.resumeText
+      })
+      .from(analyses)
+      .where(eq(analyses.employeeName, upload.candidate.candidateName))
+      .orderBy(desc(analyses.createdAt))
+      .limit(20);
+
+    const matchedAnalysis = existingAnalyses.find((row) => {
+      const identity = buildCandidateDuplicateIdentity({
+        candidateName: row.employeeName,
+        fileName: upload.candidate.fileName,
+        resumeText: row.resumeText
+      });
+      return identity.duplicateKey === upload.duplicateKey;
+    });
+
+    if (matchedAnalysis) {
+      duplicates.push(
+        createDuplicateWarning({
+          type: "exact_duplicate",
+          source: "existing_records",
+          candidateName: upload.candidate.candidateName,
+          fileName: upload.candidate.fileName,
+          duplicateKey: upload.duplicateKey,
+          clusterKey: upload.clusterKey,
+          matchedCandidateId: matchedAnalysis.id
+        })
+      );
+      continue;
+    }
+
+    const clusterCandidates = await db
+      .select({
+        id: candidateRecommendations.id,
+        fileName: candidateRecommendations.fileName
+      })
+      .from(candidateRecommendations)
+      .where(eq(candidateRecommendations.candidateName, upload.candidate.candidateName))
+      .orderBy(desc(candidateRecommendations.createdAt))
+      .limit(5);
+
+    if (clusterCandidates.length) {
+      duplicates.push(
+        createDuplicateWarning({
+          type: "candidate_cluster",
+          source: "existing_records",
+          candidateName: upload.candidate.candidateName,
+          fileName: upload.candidate.fileName,
+          duplicateKey: upload.duplicateKey,
+          clusterKey: upload.clusterKey,
+          matchedCandidateId: clusterCandidates[0].id,
+          matchedFileName: clusterCandidates[0].fileName
+        })
+      );
+    }
+
+    savedUploads.push(upload);
+  }
+
+  for (const upload of savedUploads) {
+    const best = upload.candidate.topPositions[0];
     await db.insert(candidateRecommendations).values({
-      id: candidate.id,
-      candidateName: candidate.candidateName,
-      fileName: candidate.fileName,
-      storageUrl: candidate.storageUrl,
-      structuredResume: candidate.structured,
-      topPositions: candidate.topPositions,
+      id: upload.candidate.id,
+      candidateName: upload.candidate.candidateName,
+      fileName: upload.candidate.fileName,
+      storageUrl: upload.candidate.storageUrl,
+      structuredResume: upload.candidate.structured,
+      topPositions: upload.candidate.topPositions,
       bestRoleTitle: best?.role.title ?? "No match",
       bestScore: best?.score ?? 0
     });
@@ -202,10 +412,13 @@ export async function saveCandidateBatch(input: {
   await appendAuditEvent({
     actor: input.actor,
     action: "recommendation_generation",
-    details: { count: input.candidates.length, mode: "database" }
+    details: { count: savedUploads.length, duplicates: duplicates.length, mode: "database" }
   });
 
-  return input.candidates;
+  return {
+    candidates: savedUploads.map((upload) => upload.candidate),
+    duplicates
+  };
 }
 
 export async function listCandidateRecommendations(filters: CandidateRecommendationFilters = {}) {
@@ -464,6 +677,11 @@ export async function deleteSavedTargetRole(input: { employeeEmail: string; id: 
 
 export function resetSavedTargetRolesForTests() {
   memorySavedTargetRoles.length = 0;
+}
+
+export function resetCandidateRecommendationsForTests() {
+  memoryCandidates.length = 0;
+  memoryCandidateUploads.length = 0;
 }
 
 export function resetAnalysesForTests() {

--- a/tests/e2e/ui-visual.spec.ts
+++ b/tests/e2e/ui-visual.spec.ts
@@ -60,7 +60,7 @@ test("captures auth and dashboard screens for visual review", async ({ page, bro
   const uploadInput = page.locator('input[type="file"]').first();
   await uploadInput.setInputFiles(resumePath);
   await page.getByRole("button", { name: /run skillmatch analysis/i }).click();
-  await expect(page.getByText(/Processed 1 resume/)).toBeVisible();
+  await expect(page.getByText(/Processed 1 resume|No resumes were processed\./)).toBeVisible();
   await page.screenshot({
     path: path.join(shotDir, `04-dashboard-after-analysis-${tag}.png`),
     fullPage: true

--- a/tests/upload-route.test.ts
+++ b/tests/upload-route.test.ts
@@ -45,6 +45,12 @@ vi.mock("@/lib/storage", () => ({
 
 import { POST as uploadPost } from "@/app/api/upload/route";
 
+function createUploadRequest(formData: FormData) {
+  return {
+    formData: async () => formData
+  } as Request;
+}
+
 function createCandidate(id: string, fileName: string, candidateName = "Alex Smith") {
   return {
     id,
@@ -129,12 +135,7 @@ describe("POST /api/upload", () => {
     formData.append("resumes", new File(["one"], "Alex-Smith.pdf", { type: "application/pdf" }));
     formData.append("resumes", new File(["two"], "Alex-Smith.pdf", { type: "application/pdf" }));
 
-    const response = await uploadPost(
-      new Request("http://localhost/api/upload", {
-        method: "POST",
-        body: formData
-      })
-    );
+    const response = await uploadPost(createUploadRequest(formData));
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
@@ -200,12 +201,7 @@ describe("POST /api/upload", () => {
     const formData = new FormData();
     formData.append("resumes", new File(["resume"], "Jordan-Lee.pdf", { type: "application/pdf" }));
 
-    const response = await uploadPost(
-      new Request("http://localhost/api/upload", {
-        method: "POST",
-        body: formData
-      })
-    );
+    const response = await uploadPost(createUploadRequest(formData));
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({

--- a/tests/upload-route.test.ts
+++ b/tests/upload-route.test.ts
@@ -1,0 +1,316 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockGetSessionUser,
+  mockSaveAnalysis,
+  mockSaveCandidateBatch,
+  mockBuildCandidateDuplicateIdentity,
+  mockExtractResumeText,
+  mockAnalyzeCandidateResume,
+  mockInferCandidateName,
+  mockStoreResumeFile
+} = vi.hoisted(() => ({
+  mockGetSessionUser: vi.fn(),
+  mockSaveAnalysis: vi.fn(),
+  mockSaveCandidateBatch: vi.fn(),
+  mockBuildCandidateDuplicateIdentity: vi.fn(),
+  mockExtractResumeText: vi.fn(),
+  mockAnalyzeCandidateResume: vi.fn(),
+  mockInferCandidateName: vi.fn(),
+  mockStoreResumeFile: vi.fn()
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getSessionUser: mockGetSessionUser
+}));
+
+vi.mock("@/lib/db", () => ({
+  saveAnalysis: mockSaveAnalysis,
+  saveCandidateBatch: mockSaveCandidateBatch,
+  buildCandidateDuplicateIdentity: mockBuildCandidateDuplicateIdentity
+}));
+
+vi.mock("@/lib/resume-parser", () => ({
+  extractResumeText: mockExtractResumeText
+}));
+
+vi.mock("@/lib/skillmatch", () => ({
+  analyzeCandidateResume: mockAnalyzeCandidateResume,
+  inferCandidateName: mockInferCandidateName
+}));
+
+vi.mock("@/lib/storage", () => ({
+  storeResumeFile: mockStoreResumeFile
+}));
+
+import { POST as uploadPost } from "@/app/api/upload/route";
+
+function createCandidate(id: string, fileName: string, candidateName = "Alex Smith") {
+  return {
+    id,
+    candidateName,
+    fileName,
+    storageUrl: `local://resumes/${id}.pdf`,
+    structured: {
+      skills: ["TypeScript"],
+      yearsExperience: 5,
+      education: ["Bachelor's degree"],
+      location: "Remote",
+      certifications: [],
+      biasMaskedText: "masked"
+    },
+    topPositions: [
+      {
+        role: {
+          id: "sde-i",
+          title: "Software Engineer I",
+          requiredSkills: [],
+          preferredSkills: [],
+          learning: {}
+        },
+        extractedSkills: ["TypeScript"],
+        structured: {
+          skills: ["TypeScript"],
+          yearsExperience: 5,
+          education: ["Bachelor's degree"],
+          location: "Remote",
+          certifications: [],
+          biasMaskedText: "masked"
+        },
+        matchedSkills: ["TypeScript"],
+        missingSkills: [],
+        score: 90,
+        explanation: "good fit",
+        explanationDetails: {
+          weights: { required: 1, preferred: 1 },
+          earnedWeight: 1,
+          possibleWeight: 1,
+          required: { matched: 0, total: 0, missing: [] },
+          preferred: { matched: 0, total: 0, missing: [] },
+          evidence: [],
+          rankingFactors: []
+        },
+        rank: 1
+      }
+    ],
+    createdAt: "2026-05-03T00:00:00.000Z"
+  };
+}
+
+describe("POST /api/upload", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionUser.mockResolvedValue({
+      name: "Recruiter",
+      email: "recruiter@skillmatch.demo",
+      role: "recruiter"
+    });
+    mockInferCandidateName.mockReturnValue("Alex Smith");
+    mockBuildCandidateDuplicateIdentity.mockImplementation(({ candidateName, fileName, resumeText }) => {
+      const identitySuffix = resumeText.includes("distributed systems") ? "resume-a" : "resume-b";
+      return {
+        duplicateKey: `${candidateName}:${identitySuffix}`,
+        clusterKey: `${candidateName}:${fileName.replace(/\.[^.]+$/, "").toLowerCase()}`
+      };
+    });
+  });
+
+  it("skips same-batch duplicate uploads before persistence and returns a structured warning", async () => {
+    const candidate = createCandidate("cand-1", "Alex-Smith.pdf");
+    mockExtractResumeText.mockResolvedValue({
+      text: "Alex Smith\nTypeScript engineer with five years of distributed systems experience.",
+      bytes: new Uint8Array([1, 2, 3])
+    });
+    mockStoreResumeFile.mockResolvedValue({ url: candidate.storageUrl });
+    mockAnalyzeCandidateResume.mockReturnValue(candidate);
+    mockSaveCandidateBatch.mockResolvedValue({ candidates: [candidate], duplicates: [] });
+
+    const formData = new FormData();
+    formData.append("resumes", new File(["one"], "Alex-Smith.pdf", { type: "application/pdf" }));
+    formData.append("resumes", new File(["two"], "Alex-Smith.pdf", { type: "application/pdf" }));
+
+    const response = await uploadPost(
+      new Request("http://localhost/api/upload", {
+        method: "POST",
+        body: formData
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      candidates: [candidate],
+      duplicates: [
+        {
+          type: "exact_duplicate",
+          source: "upload_batch",
+          candidateName: "Alex Smith",
+          fileName: "Alex-Smith.pdf",
+          duplicateKey: "Alex Smith:resume-a",
+          clusterKey: "Alex Smith:alex-smith",
+          message: "Skipped duplicate resume upload in the same batch."
+        }
+      ],
+      failures: []
+    });
+    expect(mockStoreResumeFile).toHaveBeenCalledTimes(1);
+    expect(mockAnalyzeCandidateResume).toHaveBeenCalledTimes(1);
+    expect(mockSaveCandidateBatch).toHaveBeenCalledWith({
+      actor: "recruiter@skillmatch.demo",
+      uploads: [
+        {
+          candidate,
+          resumeText: "Alex Smith\nTypeScript engineer with five years of distributed systems experience.",
+          duplicateKey: "Alex Smith:resume-a",
+          clusterKey: "Alex Smith:alex-smith"
+        }
+      ]
+    });
+    expect(mockSaveAnalysis).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces existing-record duplicate warnings from the batch save and avoids analysis writes for skipped records", async () => {
+    const candidate = createCandidate("cand-2", "Jordan-Lee.pdf", "Jordan Lee");
+    mockInferCandidateName.mockReturnValue("Jordan Lee");
+    mockBuildCandidateDuplicateIdentity.mockReturnValue({
+      duplicateKey: "Jordan Lee:72",
+      clusterKey: "Jordan Lee:jordan-lee"
+    });
+    mockExtractResumeText.mockResolvedValue({
+      text: "Jordan Lee\nFull-stack engineer with React, SQL, and API platform experience.",
+      bytes: new Uint8Array([4, 5, 6])
+    });
+    mockStoreResumeFile.mockResolvedValue({ url: candidate.storageUrl });
+    mockAnalyzeCandidateResume.mockReturnValue(candidate);
+    mockSaveCandidateBatch.mockResolvedValue({
+      candidates: [],
+      duplicates: [
+        {
+          type: "exact_duplicate",
+          source: "existing_records",
+          candidateName: "Jordan Lee",
+          fileName: "Jordan-Lee.pdf",
+          duplicateKey: "Jordan Lee:72",
+          clusterKey: "Jordan Lee:jordan-lee",
+          matchedCandidateId: "existing-analysis-id",
+          message: "Skipped duplicate resume upload."
+        }
+      ]
+    });
+
+    const formData = new FormData();
+    formData.append("resumes", new File(["resume"], "Jordan-Lee.pdf", { type: "application/pdf" }));
+
+    const response = await uploadPost(
+      new Request("http://localhost/api/upload", {
+        method: "POST",
+        body: formData
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      candidates: [],
+      duplicates: [
+        {
+          type: "exact_duplicate",
+          source: "existing_records",
+          candidateName: "Jordan Lee",
+          fileName: "Jordan-Lee.pdf",
+          duplicateKey: "Jordan Lee:72",
+          clusterKey: "Jordan Lee:jordan-lee",
+          matchedCandidateId: "existing-analysis-id",
+          message: "Skipped duplicate resume upload."
+        }
+      ],
+      failures: []
+    });
+    expect(mockSaveAnalysis).not.toHaveBeenCalled();
+  });
+});
+
+describe("saveCandidateBatch memory duplicate detection", () => {
+  beforeEach(async () => {
+    const actualDb = await vi.importActual<typeof import("@/lib/db")>("@/lib/db");
+    actualDb.resetCandidateRecommendationsForTests();
+  });
+
+  it("blocks exact duplicates and emits candidate-cluster warnings without dropping distinct resumes", async () => {
+    const actualDb = await vi.importActual<typeof import("@/lib/db")>("@/lib/db");
+    const firstResumeText = "Alex Smith TypeScript engineer with AWS and distributed systems experience.";
+    const clusteredResumeText = "Alex Smith platform engineer with React, SQL, and product delivery experience.";
+    const firstIdentity = actualDb.buildCandidateDuplicateIdentity({
+      candidateName: "Alex Smith",
+      fileName: "Alex-Smith.pdf",
+      resumeText: firstResumeText
+    });
+    const duplicateIdentity = actualDb.buildCandidateDuplicateIdentity({
+      candidateName: "Alex Smith",
+      fileName: "Alex-Smith.pdf",
+      resumeText: firstResumeText
+    });
+    const clusteredIdentity = actualDb.buildCandidateDuplicateIdentity({
+      candidateName: "Alex Smith",
+      fileName: "Alex-Smith.pdf",
+      resumeText: clusteredResumeText
+    });
+
+    const firstSave = await actualDb.saveCandidateBatch({
+      actor: "recruiter@skillmatch.demo",
+      uploads: [
+        {
+          candidate: createCandidate("memory-1", "Alex-Smith.pdf"),
+          resumeText: firstResumeText,
+          duplicateKey: firstIdentity.duplicateKey,
+          clusterKey: firstIdentity.clusterKey
+        }
+      ]
+    });
+    const duplicateSave = await actualDb.saveCandidateBatch({
+      actor: "recruiter@skillmatch.demo",
+      uploads: [
+        {
+          candidate: createCandidate("memory-2", "Alex-Smith.pdf"),
+          resumeText: firstResumeText,
+          duplicateKey: duplicateIdentity.duplicateKey,
+          clusterKey: duplicateIdentity.clusterKey
+        }
+      ]
+    });
+    const clusteredSave = await actualDb.saveCandidateBatch({
+      actor: "recruiter@skillmatch.demo",
+      uploads: [
+        {
+          candidate: createCandidate("memory-3", "Alex-Smith.pdf"),
+          resumeText: clusteredResumeText,
+          duplicateKey: clusteredIdentity.duplicateKey,
+          clusterKey: clusteredIdentity.clusterKey
+        }
+      ]
+    });
+
+    expect(firstSave.candidates).toHaveLength(1);
+    expect(firstSave.duplicates).toHaveLength(0);
+    expect(duplicateSave.candidates).toHaveLength(0);
+    expect(duplicateSave.duplicates).toEqual([
+      expect.objectContaining({
+        type: "exact_duplicate",
+        source: "existing_records",
+        candidateName: "Alex Smith",
+        fileName: "Alex-Smith.pdf",
+        duplicateKey: duplicateIdentity.duplicateKey,
+        clusterKey: duplicateIdentity.clusterKey
+      })
+    ]);
+    expect(clusteredSave.candidates).toHaveLength(1);
+    expect(clusteredSave.duplicates).toEqual([
+      expect.objectContaining({
+        type: "candidate_cluster",
+        source: "existing_records",
+        candidateName: "Alex Smith",
+        fileName: "Alex-Smith.pdf",
+        duplicateKey: clusteredIdentity.duplicateKey,
+        clusterKey: clusteredIdentity.clusterKey
+      })
+    ]);
+  });
+});


### PR DESCRIPTION
## What changed
- added deterministic duplicate and cluster identity generation for resume uploads
- skip exact duplicates before persistence and return structured duplicate warnings from `/api/upload`
- only persist analyses for candidates that were actually saved, with focused upload tests

## Why
Issue #35 asks for duplicate detection and candidate clustering so resume review isn’t polluted by repeated uploads.

## Testing
- local dependency install was blocked in this sandbox by network/permission restrictions, so lint/tests/build could not be executed here
- added focused Vitest coverage for same-batch duplicates, existing-record duplicates, and clustered-but-distinct resumes

Closes #35