### PR TITLE
feat: expand role readiness scoring signals

### DIFF
--- a/app/dashboard.tsx
+++ b/app/dashboard.tsx
@@ -391,6 +391,17 @@ export default function Dashboard({ user }: { user: SessionUser }) {
                   <p>Job Family: {selectedRole.family}</p>
                   <p>Business Unit: {selectedRole.department}</p>
                   <p>Level: {selectedRole.level}</p>
+                  <p>
+                    Experience: {selectedRole.minimumYearsExperience} to {selectedRole.idealYearsExperience}+ years
+                  </p>
+                  <p>
+                    Certifications:{" "}
+                    {selectedRole.requiredCertifications.concat(selectedRole.preferredCertifications).join(", ") || "None specified"}
+                  </p>
+                  <p>
+                    Soft skills:{" "}
+                    {selectedRole.requiredSoftSkills.concat(selectedRole.preferredSoftSkills).join(", ")}
+                  </p>
                 </div>
                 {notice ? <p className="notice">{notice}</p> : null}
                 {failures.map((failure) => (
@@ -417,12 +428,13 @@ export default function Dashboard({ user }: { user: SessionUser }) {
                         style={{ "--score": `${selectedResult?.score ?? 0}%` } as CSSProperties}
                         aria-label={selectedResult ? `Match score ${selectedResult.score}%` : "No match score yet"}
                       >
-                        <strong>{selectedResult ? `${selectedResult.score}%` : "—"}</strong>
+                        <strong>{selectedResult ? `${selectedResult.score}%` : "â€”"}</strong>
                       </div>
                       <strong>Overall Match</strong>
                       <span>{selectedResult ? selectedRole.title : "Upload resumes to rank positions"}</span>
                     </div>
                     <SkillList title="Top Matched Skills" items={matchedSkills.slice(0, 8)} />
+                    <ReadinessSignals result={selectedResult} />
                     <GapList gaps={missingSkills.slice(0, 8)} />
                   </div>
                   <RoleSkillGapChart
@@ -668,6 +680,47 @@ function GapList({ gaps }: { gaps: CandidateAnalysis["topPositions"][number]["mi
       ) : (
         <p className="list-placeholder">No gaps to display yet.</p>
       )}
+    </div>
+  );
+}
+
+function ReadinessSignals({ result }: { result?: CandidateAnalysis["topPositions"][number] }) {
+  if (!result) {
+    return (
+      <div>
+        <h3>
+          <BookmarkCheck aria-hidden="true" />
+          Readiness Signals
+        </h3>
+        <p className="list-placeholder">Upload a resume to compare experience, certifications, and soft skills.</p>
+      </div>
+    );
+  }
+
+  const { certifications, experience, softSkills } = result.explanationDetails;
+
+  return (
+    <div>
+      <h3>
+        <BookmarkCheck aria-hidden="true" />
+        Readiness Signals
+      </h3>
+      <ul className="match-table">
+        <li>
+          <span>Experience</span>
+          <small>
+            {experience.candidateYears ?? "Unknown"} yrs vs {experience.minimumYears}-{experience.idealYears}+ target
+          </small>
+        </li>
+        <li>
+          <span>Certifications</span>
+          <small>{certifications.matched}/{certifications.total} matched</small>
+        </li>
+        <li>
+          <span>Soft skills</span>
+          <small>{softSkills.matched}/{softSkills.total} matched</small>
+        </li>
+      </ul>
     </div>
   );
 }

--- a/lib/seed-data.ts
+++ b/lib/seed-data.ts
@@ -7,36 +7,62 @@ export type RoleRequirement = {
   location: string;
   requiredSkills: string[];
   preferredSkills: string[];
+  requiredCertifications: string[];
+  preferredCertifications: string[];
+  minimumYearsExperience: number;
+  idealYearsExperience: number;
+  requiredSoftSkills: string[];
+  preferredSoftSkills: string[];
   learning: Record<string, string>;
 };
 
 export type MatchingConfig = {
   scoringWeights: {
-    required: number;
-    preferred: number;
+    requiredSkill: number;
+    preferredSkill: number;
+    requiredCertification: number;
+    preferredCertification: number;
+    experience: number;
+    requiredSoftSkill: number;
+    preferredSoftSkill: number;
   };
   skillAliases: Record<string, string[]>;
 };
 
 export const matchingConfig: MatchingConfig = {
   scoringWeights: {
-    required: 2,
-    preferred: 1
+    requiredSkill: 2,
+    preferredSkill: 1,
+    requiredCertification: 2,
+    preferredCertification: 1,
+    experience: 2,
+    requiredSoftSkill: 1,
+    preferredSoftSkill: 1
   },
   skillAliases: {
     "api design": ["api development", "apis", "rest design", "restful api design"],
+    adaptability: ["adaptable", "adapted quickly", "flexible"],
+    analytics: ["analytical thinking", "data analysis", "product analytics"],
     aws: ["amazon web services"],
+    collaboration: ["cross functional collaboration", "cross-functional collaboration", "teamwork"],
     "ci cd": ["ci/cd", "ci-cd", "continuous integration", "continuous delivery", "continuous deployment"],
+    communication: ["written communication", "verbal communication", "presentation skills"],
+    compliance: ["regulatory compliance", "controls compliance"],
+    "customer empathy": ["customer-first mindset", "customer focus", "customer focused"],
     dashboarding: ["dashboards", "dashboard development", "bi dashboards"],
+    decision making: ["decision-making", "prioritization"],
     docker: ["dockerized", "containers", "containerization"],
     excel: ["spreadsheets", "microsoft excel"],
     git: ["github", "gitlab", "version control"],
     javascript: ["js"],
     kubernetes: ["k8s"],
+    leadership: ["team leadership", "technical leadership", "leading initiatives"],
     node: ["node.js", "nodejs"],
     postgresql: ["postgres", "postgres sql"],
+    "problem solving": ["problem-solving", "analytical problem solving", "solve complex problems"],
     "rest api": ["rest", "restful", "restful api", "rest apis", "rest services"],
     security: ["cybersecurity", "appsec", "application security"],
+    "stakeholder management": ["stakeholder alignment", "cross-functional alignment", "executive stakeholder management"],
     sql: ["structured query language"],
     testing: ["tests", "test automation", "unit testing", "vitest"],
     typescript: ["ts"]
@@ -53,6 +79,12 @@ export const roles: RoleRequirement[] = [
     location: "Seattle, WA",
     requiredSkills: ["javascript", "typescript", "react", "node", "sql", "git"],
     preferredSkills: ["aws", "testing", "api design", "docker"],
+    requiredCertifications: [],
+    preferredCertifications: ["aws certified cloud practitioner"],
+    minimumYearsExperience: 1,
+    idealYearsExperience: 2,
+    requiredSoftSkills: ["communication", "problem solving"],
+    preferredSoftSkills: ["collaboration", "adaptability"],
     learning: {
       typescript: "TypeScript Fundamentals - internal course",
       react: "React Production Patterns workshop",
@@ -61,7 +93,12 @@ export const roles: RoleRequirement[] = [
       aws: "AWS Cloud Practitioner path",
       testing: "Frontend Testing with Vitest",
       "api design": "REST API Design checklist",
-      docker: "Container Basics for App Runner"
+      docker: "Container Basics for App Runner",
+      communication: "Engineering Communication in Practice",
+      "problem solving": "Structured Problem Solving workshop",
+      collaboration: "Cross-team Delivery Essentials",
+      adaptability: "Adaptability in Fast-moving Product Teams",
+      "aws certified cloud practitioner": "AWS Cloud Practitioner certification prep"
     }
   },
   {
@@ -81,6 +118,12 @@ export const roles: RoleRequirement[] = [
       "git"
     ],
     preferredSkills: ["distributed systems", "kubernetes", "docker", "ci cd", "microservices"],
+    requiredCertifications: [],
+    preferredCertifications: ["aws certified developer associate"],
+    minimumYearsExperience: 3,
+    idealYearsExperience: 5,
+    requiredSoftSkills: ["communication", "problem solving"],
+    preferredSoftSkills: ["leadership", "collaboration"],
     learning: {
       java: "Java Engineering Foundations",
       "system design": "System Design Fundamentals",
@@ -92,7 +135,12 @@ export const roles: RoleRequirement[] = [
       kubernetes: "Kubernetes Essentials",
       docker: "Docker Deep Dive",
       "ci cd": "CI/CD with AWS CodePipeline",
-      microservices: "Microservices Design Review"
+      microservices: "Microservices Design Review",
+      communication: "Technical Design Communication workshop",
+      "problem solving": "Advanced Engineering Problem Solving",
+      leadership: "Influencing Without Authority",
+      collaboration: "Cross-team Architecture Reviews",
+      "aws certified developer associate": "AWS Developer Associate certification prep"
     }
   },
   {
@@ -104,6 +152,12 @@ export const roles: RoleRequirement[] = [
     location: "Austin, TX",
     requiredSkills: ["sql", "python", "excel", "statistics", "dashboarding"],
     preferredSkills: ["tableau", "data modeling", "communication"],
+    requiredCertifications: [],
+    preferredCertifications: ["tableau desktop specialist"],
+    minimumYearsExperience: 2,
+    idealYearsExperience: 4,
+    requiredSoftSkills: ["analytics", "decision making"],
+    preferredSoftSkills: ["stakeholder management", "collaboration"],
     learning: {
       sql: "Advanced SQL reporting lab",
       python: "Python for Analytics course",
@@ -111,7 +165,12 @@ export const roles: RoleRequirement[] = [
       dashboarding: "Dashboard Storytelling workshop",
       tableau: "Tableau Essentials",
       "data modeling": "Dimensional Modeling primer",
-      communication: "Executive Metrics Briefing practice"
+      communication: "Executive Metrics Briefing practice",
+      analytics: "Analytical Thinking for Insights Teams",
+      "stakeholder management": "Stakeholder Alignment playbook",
+      "decision making": "Data-backed Decision Making workshop",
+      collaboration: "Cross-functional Insight Delivery practice",
+      "tableau desktop specialist": "Tableau certification prep"
     }
   },
   {
@@ -123,6 +182,12 @@ export const roles: RoleRequirement[] = [
     location: "Dallas, TX",
     requiredSkills: ["aws", "linux", "networking", "troubleshooting", "customer support"],
     preferredSkills: ["python", "security", "postgresql", "docker"],
+    requiredCertifications: [],
+    preferredCertifications: ["aws certified cloud practitioner"],
+    minimumYearsExperience: 1,
+    idealYearsExperience: 3,
+    requiredSoftSkills: ["communication", "customer empathy"],
+    preferredSoftSkills: ["adaptability", "problem solving"],
     learning: {
       aws: "AWS Solutions Foundations",
       linux: "Linux Operations bootcamp",
@@ -131,7 +196,12 @@ export const roles: RoleRequirement[] = [
       "customer support": "Customer Escalation Handling",
       security: "Cloud Security Basics",
       postgresql: "Managed Databases overview",
-      docker: "Containers for Support Engineers"
+      docker: "Containers for Support Engineers",
+      communication: "Customer-facing Technical Communication",
+      "customer empathy": "Support Empathy Labs",
+      adaptability: "Shift-ready Troubleshooting practice",
+      "problem solving": "Root Cause Analysis drills",
+      "aws certified cloud practitioner": "AWS Cloud Practitioner certification prep"
     }
   },
   {
@@ -143,6 +213,12 @@ export const roles: RoleRequirement[] = [
     location: "Arlington, VA",
     requiredSkills: ["security", "aws", "linux", "python", "networking", "incident response"],
     preferredSkills: ["threat modeling", "sql", "compliance", "docker"],
+    requiredCertifications: [],
+    preferredCertifications: ["security+"],
+    minimumYearsExperience: 3,
+    idealYearsExperience: 5,
+    requiredSoftSkills: ["communication", "problem solving"],
+    preferredSoftSkills: ["leadership", "decision making"],
     learning: {
       security: "Security Engineering Foundations",
       aws: "AWS Security Specialty path",
@@ -153,7 +229,12 @@ export const roles: RoleRequirement[] = [
       "threat modeling": "Threat Modeling workshop",
       sql: "SQL for Investigations",
       compliance: "Compliance Controls overview",
-      docker: "Container Security Basics"
+      docker: "Container Security Basics",
+      communication: "Security Incident Communication playbook",
+      "problem solving": "Adversarial Problem Solving lab",
+      leadership: "Incident Leadership practice",
+      "decision making": "High-pressure Security Decision Making",
+      "security+": "CompTIA Security+ certification prep"
     }
   },
   {
@@ -165,6 +246,12 @@ export const roles: RoleRequirement[] = [
     location: "New York, NY",
     requiredSkills: ["communication", "roadmapping", "analytics", "stakeholder management", "sql"],
     preferredSkills: ["aws", "agile", "user research", "dashboarding"],
+    requiredCertifications: [],
+    preferredCertifications: ["pmp", "scrum master"],
+    minimumYearsExperience: 3,
+    idealYearsExperience: 6,
+    requiredSoftSkills: ["decision making", "leadership"],
+    preferredSoftSkills: ["collaboration", "customer empathy"],
     learning: {
       communication: "Executive Metrics Briefing practice",
       roadmapping: "Product Roadmapping workshop",
@@ -174,11 +261,18 @@ export const roles: RoleRequirement[] = [
       aws: "AWS Cloud Practitioner path",
       agile: "Agile Delivery Practices",
       "user research": "User Research Methods",
-      dashboarding: "Dashboard Storytelling workshop"
+      dashboarding: "Dashboard Storytelling workshop",
+      "decision making": "Product Decision Framing",
+      leadership: "Product Leadership Essentials",
+      collaboration: "Cross-functional Delivery Routines",
+      "customer empathy": "Voice of Customer immersion series",
+      pmp: "PMP certification prep",
+      "scrum master": "Scrum Master certification prep"
     }
   }
 ];
 
 export const sampleResume = `React developer with 2 years of experience building TypeScript dashboards.
 Skilled in JavaScript, React, Node APIs, SQL, Git, Vitest testing, and REST API design.
-Completed AWS Cloud Practitioner training and shipped Dockerized internal tools.`;
+Known for strong communication, problem solving, and cross-functional collaboration.
+Completed AWS Certified Cloud Practitioner training and shipped Dockerized internal tools.`;

--- a/lib/seed-data.ts
+++ b/lib/seed-data.ts
@@ -50,7 +50,7 @@ export const matchingConfig: MatchingConfig = {
     compliance: ["regulatory compliance", "controls compliance"],
     "customer empathy": ["customer-first mindset", "customer focus", "customer focused"],
     dashboarding: ["dashboards", "dashboard development", "bi dashboards"],
-    decision making: ["decision-making", "prioritization"],
+    "decision making": ["decision-making", "prioritization"],
     docker: ["dockerized", "containers", "containerization"],
     excel: ["spreadsheets", "microsoft excel"],
     git: ["github", "gitlab", "version control"],

--- a/lib/skillmatch.ts
+++ b/lib/skillmatch.ts
@@ -1,7 +1,11 @@
 import { matchingConfig, roles, type RoleRequirement } from "./seed-data";
 import { isKnownRoleId } from "./validation";
 
-type SkillSource = "required" | "preferred";
+type SkillSource =
+  | "required-skill"
+  | "preferred-skill"
+  | "required-soft-skill"
+  | "preferred-soft-skill";
 
 export type SkillMatchEvidence = {
   skill: string;
@@ -15,15 +19,34 @@ export type SkillMatchExplanationDetails = {
   weights: typeof matchingConfig.scoringWeights;
   earnedWeight: number;
   possibleWeight: number;
-  required: {
+  requiredSkills: {
     matched: number;
     total: number;
     missing: string[];
   };
-  preferred: {
+  preferredSkills: {
     matched: number;
     total: number;
     missing: string[];
+  };
+  softSkills: {
+    matched: number;
+    total: number;
+    missing: string[];
+  };
+  certifications: {
+    matched: number;
+    total: number;
+    matchedItems: string[];
+    missing: string[];
+  };
+  experience: {
+    candidateYears: number | null;
+    minimumYears: number;
+    idealYears: number;
+    earnedWeight: number;
+    meetsMinimum: boolean;
+    meetsIdeal: boolean;
   };
   evidence: SkillMatchEvidence[];
   rankingFactors: string[];
@@ -36,6 +59,7 @@ export type SkillMatchResult = {
   matchedSkills: string[];
   missingSkills: Array<{
     skill: string;
+    category: "skill" | "soft-skill" | "certification" | "experience";
     importance: "critical" | "important";
     recommendation: string;
   }>;
@@ -68,7 +92,14 @@ export type CandidateAnalysis = {
 };
 
 const canonicalSkills = Array.from(
-  new Set(roles.flatMap((role) => [...role.requiredSkills, ...role.preferredSkills]))
+  new Set(
+    roles.flatMap((role) => [
+      ...role.requiredSkills,
+      ...role.preferredSkills,
+      ...role.requiredSoftSkills,
+      ...role.preferredSoftSkills
+    ])
+  )
 );
 
 const skillVocabulary = canonicalSkills.sort((a, b) => b.length - a.length);
@@ -196,73 +227,255 @@ export function extractStructuredResume(resumeText: string): StructuredResume {
   };
 }
 
+function normalizeIdentifier(value: string) {
+  return normalizeResumeText(value);
+}
+
+function findMatchingCertification(
+  extractedCertifications: string[],
+  certification: string
+) {
+  const normalizedCertification = normalizeIdentifier(certification);
+  return (
+    extractedCertifications.find((item) => {
+      const normalizedItem = normalizeIdentifier(item);
+      return (
+        normalizedItem.includes(normalizedCertification) ||
+        normalizedCertification.includes(normalizedItem)
+      );
+    }) ?? null
+  );
+}
+
+function calculateExperienceWeight(
+  candidateYears: number | null,
+  minimumYears: number,
+  idealYears: number
+) {
+  if (candidateYears === null) {
+    return 0;
+  }
+
+  if (candidateYears >= idealYears) {
+    return matchingConfig.scoringWeights.experience;
+  }
+
+  if (candidateYears >= minimumYears) {
+    if (idealYears <= minimumYears) {
+      return matchingConfig.scoringWeights.experience;
+    }
+
+    const progress = (candidateYears - minimumYears) / (idealYears - minimumYears);
+    return matchingConfig.scoringWeights.experience * (0.75 + progress * 0.25);
+  }
+
+  if (minimumYears <= 0) {
+    return 0;
+  }
+
+  return matchingConfig.scoringWeights.experience * Math.min(candidateYears / minimumYears, 0.5);
+}
+
 export function analyzeResume(resumeText: string, roleId: string): SkillMatchResult {
   const safeRoleId = isKnownRoleId(roleId) ? roleId : roles[0].id;
   const role = roles.find((item) => item.id === safeRoleId) ?? roles[0];
   const structured = extractStructuredResume(resumeText);
   const extractedSkills = structured.skills;
   const extracted = new Set(extractedSkills);
-  const allRoleSkills = [...role.requiredSkills, ...role.preferredSkills];
-  const matchedSkills = allRoleSkills.filter((skill) => extracted.has(skill));
-  const missingRequired = role.requiredSkills.filter((skill) => !extracted.has(skill));
-  const missingPreferred = role.preferredSkills.filter((skill) => !extracted.has(skill));
-  const { required: requiredSkillWeight, preferred: preferredSkillWeight } = matchingConfig.scoringWeights;
+  const skillAndSoftSkillTargets = [
+    ...role.requiredSkills,
+    ...role.preferredSkills,
+    ...role.requiredSoftSkills,
+    ...role.preferredSoftSkills
+  ];
+  const matchedSkills = skillAndSoftSkillTargets.filter((skill) => extracted.has(skill));
+  const missingRequiredSkills = role.requiredSkills.filter((skill) => !extracted.has(skill));
+  const missingPreferredSkills = role.preferredSkills.filter((skill) => !extracted.has(skill));
+  const missingRequiredSoftSkills = role.requiredSoftSkills.filter((skill) => !extracted.has(skill));
+  const missingPreferredSoftSkills = role.preferredSoftSkills.filter((skill) => !extracted.has(skill));
+  const matchedRequiredCertifications = role.requiredCertifications
+    .map((certification) => findMatchingCertification(structured.certifications, certification))
+    .filter((certification): certification is string => Boolean(certification));
+  const matchedPreferredCertifications = role.preferredCertifications
+    .map((certification) => findMatchingCertification(structured.certifications, certification))
+    .filter((certification): certification is string => Boolean(certification));
+  const missingRequiredCertifications = role.requiredCertifications.filter(
+    (certification) => !findMatchingCertification(structured.certifications, certification)
+  );
+  const missingPreferredCertifications = role.preferredCertifications.filter(
+    (certification) => !findMatchingCertification(structured.certifications, certification)
+  );
+  const {
+    requiredSkill,
+    preferredSkill,
+    requiredCertification,
+    preferredCertification,
+    experience,
+    requiredSoftSkill,
+    preferredSoftSkill
+  } = matchingConfig.scoringWeights;
 
-  const requiredWeight = role.requiredSkills.length * requiredSkillWeight;
-  const preferredWeight = role.preferredSkills.length * preferredSkillWeight;
+  const possibleWeight =
+    role.requiredSkills.length * requiredSkill +
+    role.preferredSkills.length * preferredSkill +
+    role.requiredCertifications.length * requiredCertification +
+    role.preferredCertifications.length * preferredCertification +
+    experience +
+    role.requiredSoftSkills.length * requiredSoftSkill +
+    role.preferredSoftSkills.length * preferredSoftSkill;
   const earned =
-    role.requiredSkills.filter((skill) => extracted.has(skill)).length * requiredSkillWeight +
-    role.preferredSkills.filter((skill) => extracted.has(skill)).length * preferredSkillWeight;
-  const possibleWeight = requiredWeight + preferredWeight;
+    (role.requiredSkills.length - missingRequiredSkills.length) * requiredSkill +
+    (role.preferredSkills.length - missingPreferredSkills.length) * preferredSkill +
+    matchedRequiredCertifications.length * requiredCertification +
+    matchedPreferredCertifications.length * preferredCertification +
+    calculateExperienceWeight(
+      structured.yearsExperience,
+      role.minimumYearsExperience,
+      role.idealYearsExperience
+    ) +
+    (role.requiredSoftSkills.length - missingRequiredSoftSkills.length) * requiredSoftSkill +
+    (role.preferredSoftSkills.length - missingPreferredSoftSkills.length) * preferredSoftSkill;
   const score = possibleWeight > 0 ? Math.round((earned / possibleWeight) * 100) : 0;
 
   const normalizedResume = normalizeResumeText(resumeText);
-  const evidence = allRoleSkills
+  const evidence = skillAndSoftSkillTargets
     .filter((skill) => extracted.has(skill))
     .map((skill) => {
-      const source: SkillSource = role.requiredSkills.includes(skill) ? "required" : "preferred";
+      const source: SkillSource = role.requiredSkills.includes(skill)
+        ? "required-skill"
+        : role.preferredSkills.includes(skill)
+          ? "preferred-skill"
+          : role.requiredSoftSkills.includes(skill)
+            ? "required-soft-skill"
+            : "preferred-soft-skill";
       const terms = skillTerms.get(skill) ?? [skill];
       return {
         skill,
         matchedText: findMatchedTerm(normalizedResume, skill) ?? skill,
         snippet: findEvidenceSnippet(resumeText, terms),
         source,
-        weight: source === "required" ? requiredSkillWeight : preferredSkillWeight
+        weight:
+          source === "required-skill"
+            ? requiredSkill
+            : source === "preferred-skill"
+              ? preferredSkill
+              : source === "required-soft-skill"
+                ? requiredSoftSkill
+                : preferredSoftSkill
       };
     });
 
   const missingSkills = [
-    ...missingRequired.map((skill) => ({
+    ...missingRequiredSkills.map((skill) => ({
       skill,
+      category: "skill" as const,
       importance: "critical" as const,
       recommendation: role.learning[skill] ?? `Complete focused training for ${skill}.`
     })),
-    ...missingPreferred.map((skill) => ({
+    ...missingPreferredSkills.map((skill) => ({
       skill,
+      category: "skill" as const,
       importance: "important" as const,
       recommendation: role.learning[skill] ?? `Review applied ${skill} practice.`
-    }))
+    })),
+    ...missingRequiredSoftSkills.map((skill) => ({
+      skill,
+      category: "soft-skill" as const,
+      importance: "critical" as const,
+      recommendation: role.learning[skill] ?? `Practice role-relevant examples that demonstrate ${skill}.`
+    })),
+    ...missingPreferredSoftSkills.map((skill) => ({
+      skill,
+      category: "soft-skill" as const,
+      importance: "important" as const,
+      recommendation: role.learning[skill] ?? `Strengthen evidence of ${skill} through recent projects.`
+    })),
+    ...missingRequiredCertifications.map((skill) => ({
+      skill,
+      category: "certification" as const,
+      importance: "critical" as const,
+      recommendation: role.learning[skill] ?? `Complete the certification path for ${skill}.`
+    })),
+    ...missingPreferredCertifications.map((skill) => ({
+      skill,
+      category: "certification" as const,
+      importance: "important" as const,
+      recommendation: role.learning[skill] ?? `Consider adding ${skill} to strengthen role readiness.`
+    })),
+    ...(structured.yearsExperience !== null && structured.yearsExperience >= role.minimumYearsExperience
+      ? []
+      : [
+          {
+            skill: `${role.minimumYearsExperience}+ years of experience`,
+            category: "experience" as const,
+            importance: "critical" as const,
+            recommendation: `Build more directly relevant experience toward the ${role.minimumYearsExperience}-year baseline for ${role.title}.`
+          }
+        ]),
+    ...(structured.yearsExperience !== null && structured.yearsExperience >= role.idealYearsExperience
+      ? []
+      : [
+          {
+            skill: `${role.idealYearsExperience}+ years of experience`,
+            category: "experience" as const,
+            importance: "important" as const,
+            recommendation: `Continue building depth toward the ${role.idealYearsExperience}-year target for stronger leveling confidence.`
+          }
+        ])
   ];
 
+  const experienceWeight = calculateExperienceWeight(
+    structured.yearsExperience,
+    role.minimumYearsExperience,
+    role.idealYearsExperience
+  );
   const explanationDetails: SkillMatchExplanationDetails = {
     weights: matchingConfig.scoringWeights,
     earnedWeight: earned,
     possibleWeight,
-    required: {
-      matched: role.requiredSkills.length - missingRequired.length,
+    requiredSkills: {
+      matched: role.requiredSkills.length - missingRequiredSkills.length,
       total: role.requiredSkills.length,
-      missing: missingRequired
+      missing: missingRequiredSkills
     },
-    preferred: {
-      matched: role.preferredSkills.length - missingPreferred.length,
+    preferredSkills: {
+      matched: role.preferredSkills.length - missingPreferredSkills.length,
       total: role.preferredSkills.length,
-      missing: missingPreferred
+      missing: missingPreferredSkills
+    },
+    softSkills: {
+      matched:
+        role.requiredSoftSkills.length +
+        role.preferredSoftSkills.length -
+        missingRequiredSoftSkills.length -
+        missingPreferredSoftSkills.length,
+      total: role.requiredSoftSkills.length + role.preferredSoftSkills.length,
+      missing: [...missingRequiredSoftSkills, ...missingPreferredSoftSkills]
+    },
+    certifications: {
+      matched: matchedRequiredCertifications.length + matchedPreferredCertifications.length,
+      total: role.requiredCertifications.length + role.preferredCertifications.length,
+      matchedItems: [...matchedRequiredCertifications, ...matchedPreferredCertifications],
+      missing: [...missingRequiredCertifications, ...missingPreferredCertifications]
+    },
+    experience: {
+      candidateYears: structured.yearsExperience,
+      minimumYears: role.minimumYearsExperience,
+      idealYears: role.idealYearsExperience,
+      earnedWeight: experienceWeight,
+      meetsMinimum:
+        structured.yearsExperience !== null && structured.yearsExperience >= role.minimumYearsExperience,
+      meetsIdeal:
+        structured.yearsExperience !== null && structured.yearsExperience >= role.idealYearsExperience
     },
     evidence,
     rankingFactors: [
-      `${role.requiredSkills.length - missingRequired.length}/${role.requiredSkills.length} required skills matched`,
-      `${role.preferredSkills.length - missingPreferred.length}/${role.preferredSkills.length} preferred skills matched`,
-      `${earned}/${possibleWeight} weighted points earned`
+      `${role.requiredSkills.length - missingRequiredSkills.length}/${role.requiredSkills.length} required hard skills matched`,
+      `${role.preferredSkills.length - missingPreferredSkills.length}/${role.preferredSkills.length} preferred hard skills matched`,
+      `${role.requiredSoftSkills.length + role.preferredSoftSkills.length - missingRequiredSoftSkills.length - missingPreferredSoftSkills.length}/${role.requiredSoftSkills.length + role.preferredSoftSkills.length} soft skills matched`,
+      `${matchedRequiredCertifications.length + matchedPreferredCertifications.length}/${role.requiredCertifications.length + role.preferredCertifications.length} certifications matched`,
+      `Experience signal contributed ${experienceWeight.toFixed(2)}/${experience} weighted points`,
+      `${earned.toFixed(2)}/${possibleWeight} weighted points earned`
     ]
   };
 
@@ -273,7 +486,7 @@ export function analyzeResume(resumeText: string, roleId: string): SkillMatchRes
     matchedSkills,
     missingSkills,
     score,
-    explanation: `Score is based on configurable weighted overlap with ${role.title}: required skills count ${requiredSkillWeight}x, preferred skills count ${preferredSkillWeight}x. ${explanationDetails.required.matched} of ${role.requiredSkills.length} required skills and ${explanationDetails.preferred.matched} of ${role.preferredSkills.length} preferred skills matched (${earned}/${possibleWeight} weighted points). Evidence snippets are captured for matched skills, and demographic contact signals are masked before recommendation review.`,
+    explanation: `Score is based on configurable weighted overlap with ${role.title}: required hard skills count ${requiredSkill}x, preferred hard skills count ${preferredSkill}x, required certifications count ${requiredCertification}x, preferred certifications count ${preferredCertification}x, experience contributes ${experience} points, and soft skills count ${requiredSoftSkill}x/${preferredSoftSkill}x. ${explanationDetails.requiredSkills.matched} of ${role.requiredSkills.length} required hard skills, ${explanationDetails.preferredSkills.matched} of ${role.preferredSkills.length} preferred hard skills, ${explanationDetails.softSkills.matched} of ${explanationDetails.softSkills.total} soft skills, and ${explanationDetails.certifications.matched} of ${explanationDetails.certifications.total} certifications matched. Candidate experience is ${structured.yearsExperience ?? "unknown"} years against a ${role.minimumYearsExperience}-${role.idealYearsExperience}+ year target (${earned.toFixed(2)}/${possibleWeight} weighted points). Evidence snippets are captured for matched competencies, and demographic contact signals are masked before recommendation review.`,
     explanationDetails
   };
 }

--- a/tests/skillmatch.test.ts
+++ b/tests/skillmatch.test.ts
@@ -21,12 +21,20 @@ describe("skill matching engine", () => {
   });
 
   it("weights required skills more than preferred skills", () => {
-    const result = analyzeResume("TypeScript React JavaScript Node SQL Git testing", "sde-i");
+    const result = analyzeResume(
+      [
+        "TypeScript React JavaScript Node SQL Git testing Docker.",
+        "2 years of experience building dashboards.",
+        "AWS Certified Cloud Practitioner.",
+        "Strong communication, problem solving, collaboration, and adaptability."
+      ].join(" "),
+      "sde-i"
+    );
 
     expect(result.score).toBeGreaterThanOrEqual(80);
     expect(result.matchedSkills).toContain("typescript");
-    expect(result.missingSkills.map((item) => item.skill)).toContain("aws");
-    expect(result.explanation).toContain("required skills count 2x");
+    expect(result.missingSkills.map((item) => item.skill)).toContain("api design");
+    expect(result.explanation).toContain("required hard skills count 2x");
     expect(result.explanationDetails.earnedWeight).toBeGreaterThan(result.matchedSkills.length);
   });
 
@@ -38,7 +46,7 @@ describe("skill matching engine", () => {
 
   it("ranks good positions for each resume", () => {
     const recommendations = rankResumeForPositions(
-      "Java engineer with AWS, SQL, REST API, Git, system design, Docker, and data structures experience."
+      "Java engineer with 5 years experience, AWS, SQL, REST API, Git, system design, Docker, data structures, communication, and collaboration."
     );
 
     expect(recommendations[0].role.id).toBe("sde-ii");
@@ -85,7 +93,57 @@ describe("skill matching engine", () => {
     expect(result.score).toBe(0);
     expect(result.matchedSkills).toEqual([]);
     expect(result.explanationDetails.evidence).toEqual([]);
-    expect(result.missingSkills).toHaveLength(10);
+    expect(result.missingSkills).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ category: "skill", skill: "javascript" }),
+        expect.objectContaining({ category: "soft-skill", skill: "communication" }),
+        expect.objectContaining({ category: "certification", skill: "aws certified cloud practitioner" }),
+        expect.objectContaining({ category: "experience", skill: "1+ years of experience" })
+      ])
+    );
+  });
+
+  it("accounts for certifications, experience, and soft skills in scoring", () => {
+    const result = analyzeResume(
+      [
+        "Software engineer with 5 years of experience building Java systems on AWS.",
+        "AWS Certified Developer Associate.",
+        "Strong communication, leadership, collaboration, system design, SQL, REST API, Git, and data structures."
+      ].join(" "),
+      "sde-ii"
+    );
+
+    expect(result.score).toBeGreaterThanOrEqual(75);
+    expect(result.matchedSkills).toEqual(
+      expect.arrayContaining(["communication", "leadership", "collaboration", "aws", "git"])
+    );
+    expect(result.explanationDetails.certifications.matchedItems).toEqual(
+      expect.arrayContaining(["AWS Certified Developer Associate"])
+    );
+    expect(result.explanationDetails.experience.meetsIdeal).toBe(true);
+    expect(result.explanationDetails.softSkills.matched).toBeGreaterThanOrEqual(3);
+  });
+
+  it("surfaces readiness gaps when certification or experience signals are missing", () => {
+    const result = analyzeResume(
+      "Product manager with 2 years experience, strong communication, analytics, SQL, and roadmapping.",
+      "product-manager"
+    );
+
+    expect(result.explanationDetails.experience.meetsMinimum).toBe(false);
+    expect(result.explanationDetails.certifications.missing).toEqual(expect.arrayContaining(["pmp", "scrum master"]));
+    expect(result.missingSkills).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          category: "experience",
+          skill: "3+ years of experience"
+        }),
+        expect.objectContaining({
+          category: "certification",
+          skill: "pmp"
+        })
+      ])
+    );
   });
 
   it("extracts structured resume data and masks demographic signals", () => {


### PR DESCRIPTION
## What changed
- expanded the role model to include certifications, experience targets, and soft-skill requirements
- updated resume scoring and explanations to account for those readiness signals
- surfaced the new requirements and readiness summary in the dashboard with focused matcher tests

## Why
Issue #43 asks for role requirements and ranking logic to consider certifications, years of experience, and soft skills instead of only hard-skill overlap.

## Testing
- local dependency install was blocked in this sandbox by network/permission restrictions, so lint/tests/build could not be executed here
- added focused unit coverage for certification, experience, and soft-skill scoring behavior

Closes #43