### PR TITLE
Allow learning modules to be assigned to resumes

### DIFF
--- a/app/api/candidates/[id]/learning-modules/route.ts
+++ b/app/api/candidates/[id]/learning-modules/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { getSessionUser } from "@/lib/auth";
+import { assignCandidateLearningModules } from "@/lib/db";
+import { serverErrorResponse } from "@/lib/server-api-error";
+
+export async function PUT(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const user = await getSessionUser();
+  if (!user) {
+    return NextResponse.json({ error: "Authentication required." }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const body = (await request.json().catch(() => null)) as { moduleIds?: unknown } | null;
+  if (!body || !Array.isArray(body.moduleIds) || !body.moduleIds.every((item) => typeof item === "string")) {
+    return NextResponse.json({ error: "moduleIds must be an array of strings." }, { status: 400 });
+  }
+
+  try {
+    const candidate = await assignCandidateLearningModules({
+      actor: user.email,
+      candidateId: id,
+      moduleIds: body.moduleIds
+    });
+
+    if (!candidate) {
+      return NextResponse.json({ error: "Candidate resume not found." }, { status: 404 });
+    }
+
+    return NextResponse.json({ candidate });
+  } catch (error) {
+    return serverErrorResponse(error);
+  }
+}

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -11,7 +11,10 @@ const requiredTables = [
 ] as const;
 
 /** Tables expected to exist; columns checked only when the table is already present. */
-const requiredColumns = [{ table: "candidate_recommendations", column: "ai_insight" }] as const;
+const requiredColumns = [
+  { table: "candidate_recommendations", column: "ai_insight" },
+  { table: "candidate_recommendations", column: "assigned_learning_modules" }
+] as const;
 
 export const dynamic = "force-dynamic";
 

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -15,6 +15,7 @@ import {
   type CandidateAnalysis,
 } from "@/lib/skillmatch";
 import { isAllowedResumeUpload } from "@/lib/resume-upload-validation";
+import { serverErrorResponse } from "@/lib/server-api-error";
 import { storeResumeFile } from "@/lib/storage";
 
 const maxFiles = 12;
@@ -23,12 +24,13 @@ const maxFileSize = 8 * 1024 * 1024;
 const maxZipFileSize = 25 * 1024 * 1024;
 
 export async function POST(request: Request) {
-  const user = await getSessionUser();
-  if (!user) {
-    return NextResponse.json({ error: "Authentication required." }, { status: 401 });
-  }
+  try {
+    const user = await getSessionUser();
+    if (!user) {
+      return NextResponse.json({ error: "Authentication required." }, { status: 401 });
+    }
 
-  const formData = await request.formData();
+    const formData = await request.formData();
   const rawFiles = formData
     .getAll("resumes")
     .filter((item): item is File => item instanceof File && item.size > 0);
@@ -205,5 +207,8 @@ export async function POST(request: Request) {
     body.persistError = persistError;
   }
 
-  return NextResponse.json(body);
+    return NextResponse.json(body);
+  } catch (error) {
+    return serverErrorResponse(error);
+  }
 }

--- a/app/dashboard.tsx
+++ b/app/dashboard.tsx
@@ -26,7 +26,7 @@ import {
   X,
   type LucideIcon
 } from "lucide-react";
-import { roles } from "@/lib/seed-data";
+import { roles, type RoleRequirement } from "@/lib/seed-data";
 import type { SessionUser } from "@/lib/auth-model";
 import type {
   AnalysisRecord,
@@ -68,6 +68,10 @@ function fileKey(file: File) {
 
 function candidateHasStoredResumeFile(candidate: Pick<CandidateAnalysis, "storageUrl" | "fileName">) {
   return Boolean(candidate.storageUrl?.trim() && candidate.fileName?.trim());
+}
+
+function learningModuleId(roleId: string, skill: string) {
+  return `${roleId}:${skill}`;
 }
 
 function CandidateResumeFileLinks({ candidate }: { candidate: CandidateAnalysis }) {
@@ -114,6 +118,8 @@ export default function Dashboard({
   const [uploadDuplicateWarnings, setUploadDuplicateWarnings] = useState<CandidateDuplicateWarning[]>([]);
   const [overrideCandidate, setOverrideCandidate] = useState<CandidateAnalysis | null>(null);
   const [selectedCandidateId, setSelectedCandidateId] = useState<string>("");
+  const [selectedLearningCandidateId, setSelectedLearningCandidateId] = useState<string>("");
+  const [learningAssignmentStatus, setLearningAssignmentStatus] = useState<"idle" | "saving">("idle");
   const [isUploading, setIsUploading] = useState(false);
   const [notice, setNotice] = useState("");
   const [analysisHistoryStatus, setAnalysisHistoryStatus] = useState<
@@ -142,6 +148,8 @@ export default function Dashboard({
 
   const selectedRole = roles.find((role) => role.id === roleId) ?? roles[0];
   const selectedCandidate = candidates.find((candidate) => candidate.id === selectedCandidateId) ?? candidates[0];
+  const selectedLearningCandidate =
+    candidates.find((candidate) => candidate.id === selectedLearningCandidateId) ?? selectedCandidate;
   const selectedRoleMatch = selectedCandidate?.topPositions.find((item) => item.role.id === roleId);
   const bestRecommendation = selectedRoleMatch ?? selectedCandidate?.topPositions[0];
   const selectedResult = selectedRoleMatch ?? bestRecommendation;
@@ -231,6 +239,16 @@ export default function Dashboard({
           const payload = (await candidateResponse.json()) as { candidates: CandidateAnalysis[] };
           setCandidates(payload.candidates);
           setSelectedCandidateId((current) => {
+            const ids = new Set(payload.candidates.map((c) => c.id));
+            if (!payload.candidates.length) {
+              return "";
+            }
+            if (current && ids.has(current)) {
+              return current;
+            }
+            return payload.candidates[0]!.id;
+          });
+          setSelectedLearningCandidateId((current) => {
             const ids = new Set(payload.candidates.map((c) => c.id));
             if (!payload.candidates.length) {
               return "";
@@ -473,6 +491,38 @@ export default function Dashboard({
     }
     const payload = (await response.json().catch(() => ({}))) as { error?: string };
     setNotice(payload.error ?? "Could not remove this bookmark. Try again.");
+  }
+
+  async function assignLearningModule(moduleId: string, assigned: boolean) {
+    if (!selectedLearningCandidate) {
+      setNotice("Select a resume before assigning learning modules.");
+      return;
+    }
+
+    const currentModules = new Set(selectedLearningCandidate.assignedLearningModules ?? []);
+    if (assigned) {
+      currentModules.add(moduleId);
+    } else {
+      currentModules.delete(moduleId);
+    }
+
+    setLearningAssignmentStatus("saving");
+    const response = await fetch(`/api/candidates/${selectedLearningCandidate.id}/learning-modules`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ moduleIds: Array.from(currentModules) })
+    });
+
+    setLearningAssignmentStatus("idle");
+    if (!response.ok) {
+      const payload = (await response.json().catch(() => ({}))) as { error?: string };
+      setNotice(payload.error ?? "Could not update learning assignments.");
+      return;
+    }
+
+    const payload = (await response.json()) as { candidate: CandidateAnalysis };
+    setCandidates((current) => current.map((candidate) => (candidate.id === payload.candidate.id ? payload.candidate : candidate)));
+    setNotice(`Updated learning modules for ${payload.candidate.candidateName}.`);
   }
 
   async function logout() {
@@ -818,7 +868,24 @@ export default function Dashboard({
         {view === "learning" ? (
           <section className="screen-stack">
             <div className="screen-toolbar">
-              <span className="text-[13px] text-muted">Bookmarks & metrics refresh from the server.</span>
+              <label className="role-context learning-resume-picker">
+                Resume
+                <select
+                  value={selectedLearningCandidate?.id ?? ""}
+                  onChange={(event) => setSelectedLearningCandidateId(event.target.value)}
+                  disabled={!candidates.length}
+                >
+                  {candidates.length ? (
+                    candidates.map((candidate) => (
+                      <option key={candidate.id} value={candidate.id}>
+                        {candidate.candidateName} - {candidate.fileName}
+                      </option>
+                    ))
+                  ) : (
+                    <option value="">Upload a resume first</option>
+                  )}
+                </select>
+              </label>
               <button className="icon-text-button" type="button" onClick={() => void refreshRecords()}>
                 Refresh
               </button>
@@ -826,28 +893,17 @@ export default function Dashboard({
             <section className="metric-grid">
               <Metric label="Saved target roles" value={savedRoles.length} />
               <Metric label="Current role progress" value={savedCurrentRole ? `${savedCurrentRole.progressPercent}%` : "Not saved"} />
-              <Metric label="Target match score" value={savedCurrentRole ? `${savedCurrentRole.targetScore}%` : "80%"} />
+              <Metric
+                label="Assigned modules"
+                value={selectedLearningCandidate?.assignedLearningModules?.length ?? 0}
+              />
             </section>
-            <section className="concept-panel">
-              <div className="panel-heading">
-                <h2>Learning Recommendations</h2>
-                <span>{selectedRole.title}</span>
-              </div>
-              <p className="m-0 mb-3 text-[12px] font-semibold uppercase tracking-wide text-muted">
-                Demo mapping — not wired to LMS
-              </p>
-              <div className="learning-grid">
-                {Object.entries(selectedRole.learning).map(([skill, course]) => (
-                  <article className="learning-item" key={skill}>
-                    <GraduationCap aria-hidden="true" />
-                    <div>
-                      <strong>{course}</strong>
-                      <span>{skill}</span>
-                    </div>
-                  </article>
-                ))}
-              </div>
-            </section>
+            <LearningAssignmentPanel
+              busy={learningAssignmentStatus === "saving"}
+              candidate={selectedLearningCandidate}
+              onToggle={(moduleId, assigned) => void assignLearningModule(moduleId, assigned)}
+              role={selectedRole}
+            />
             <SavedRoleProgress roles={savedRoles} onRemove={removeSavedRole} onSelect={setRoleId} />
           </section>
         ) : null}
@@ -1454,6 +1510,70 @@ function SavedRoleProgress({
           title="No saved target roles"
           text="Bookmark a comparison role from the dashboard sidebar to track gap progress on Learning. Uploaded candidates already appear under Analyses—that action only pins the job role for progress, not the résumés."
         />
+      )}
+    </section>
+  );
+}
+
+function LearningAssignmentPanel({
+  busy,
+  candidate,
+  onToggle,
+  role
+}: {
+  busy: boolean;
+  candidate?: CandidateAnalysis;
+  onToggle: (moduleId: string, assigned: boolean) => void;
+  role: RoleRequirement;
+}) {
+  const assignedModules = new Set(candidate?.assignedLearningModules ?? []);
+  const candidateMissingSkills = new Set(
+    candidate?.topPositions.find((position) => position.role.id === role.id)?.missingSkills.map((gap) => gap.skill) ??
+      candidate?.topPositions[0]?.missingSkills.map((gap) => gap.skill) ??
+      []
+  );
+
+  return (
+    <section className="concept-panel">
+      <div className="panel-heading">
+        <h2>Learning Module Assignments</h2>
+        <span>{candidate ? role.title : "No resume selected"}</span>
+      </div>
+      {candidate ? (
+        <>
+          <p className="m-0 mb-3 text-[12px] leading-snug text-muted">
+            Assign role-specific learning modules directly to {candidate.candidateName}&apos;s saved resume.
+          </p>
+          <div className="learning-grid">
+            {Object.entries(role.learning).map(([skill, course]) => {
+              const moduleId = learningModuleId(role.id, skill);
+              const assigned = assignedModules.has(moduleId);
+              const recommended = candidateMissingSkills.has(skill);
+              return (
+                <article className={`learning-item learning-assignment-item ${assigned ? "is-assigned" : ""}`} key={moduleId}>
+                  <GraduationCap aria-hidden="true" />
+                  <div>
+                    <strong>{course}</strong>
+                    <span>
+                      {skill}
+                      {recommended ? " - gap match" : ""}
+                    </span>
+                  </div>
+                  <button
+                    className={assigned ? "icon-text-button assigned-module-button" : "icon-text-button"}
+                    disabled={busy}
+                    onClick={() => onToggle(moduleId, !assigned)}
+                    type="button"
+                  >
+                    {assigned ? "Assigned" : "Assign"}
+                  </button>
+                </article>
+              );
+            })}
+          </div>
+        </>
+      ) : (
+        <p className="list-placeholder">Upload and analyze a resume, then assign learning modules from this screen.</p>
       )}
     </section>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -1644,6 +1644,24 @@ meter::-moz-meter-bar {
   padding: 16px;
 }
 
+.learning-assignment-item {
+  grid-template-columns: 28px minmax(0, 1fr) auto;
+}
+
+.learning-assignment-item.is-assigned {
+  border-color: #86efac;
+  background: var(--green-bg);
+}
+
+.assigned-module-button {
+  border-color: #86efac;
+  color: #065f46;
+}
+
+.learning-resume-picker {
+  min-width: min(520px, 100%);
+}
+
 .learning-item svg {
   color: var(--blue);
 }

--- a/db/migrations/0005_candidate_learning_modules.sql
+++ b/db/migrations/0005_candidate_learning_modules.sql
@@ -1,0 +1,2 @@
+alter table candidate_recommendations
+  add column if not exists assigned_learning_modules jsonb not null default '[]'::jsonb;

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1778010000000,
       "tag": "0004_enforce_user_role",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1778020000000,
+      "tag": "0005_candidate_learning_modules",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -48,6 +48,7 @@ create table if not exists candidate_recommendations (
   storage_url text not null,
   structured_resume jsonb not null,
   top_positions jsonb not null,
+  assigned_learning_modules jsonb not null default '[]'::jsonb,
   best_role_title text not null,
   best_score integer not null check (best_score >= 0 and best_score <= 100),
   created_at timestamptz not null default now()

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -68,6 +68,7 @@ export const candidateRecommendations = pgTable(
     structuredResume: jsonb("structured_resume").notNull(),
     topPositions: jsonb("top_positions").notNull(),
     aiInsight: jsonb("ai_insight").$type<ResumeAiInsight | null>(),
+    assignedLearningModules: jsonb("assigned_learning_modules").$type<string[]>().notNull().default(sql`'[]'::jsonb`),
     bestRoleTitle: text("best_role_title").notNull(),
     bestScore: integer("best_score").notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow()

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -43,6 +43,7 @@ export type CandidateUploadRecord = {
 function normalizeCandidateRecommendation(candidate: CandidateAnalysis): CandidateAnalysis {
   return {
     ...candidate,
+    assignedLearningModules: candidate.assignedLearningModules ?? [],
     topPositions: candidate.topPositions.map((position) => {
       const details = position.explanationDetails as Partial<CandidatePositionRecommendation["explanationDetails"]> | undefined;
       return {
@@ -455,6 +456,7 @@ export async function saveCandidateBatch(input: {
       structuredResume: upload.candidate.structured,
       topPositions: upload.candidate.topPositions,
       aiInsight: upload.candidate.aiInsight,
+      assignedLearningModules: upload.candidate.assignedLearningModules,
       bestRoleTitle: best?.role.title ?? "No match",
       bestScore: best?.score ?? 0
     });
@@ -488,6 +490,7 @@ export async function listCandidateRecommendations(filters: CandidateRecommendat
       structured: candidateRecommendations.structuredResume,
       topPositions: candidateRecommendations.topPositions,
       aiInsight: candidateRecommendations.aiInsight,
+      assignedLearningModules: candidateRecommendations.assignedLearningModules,
       createdAt: candidateRecommendations.createdAt
     })
     .from(candidateRecommendations)
@@ -502,10 +505,84 @@ export async function listCandidateRecommendations(filters: CandidateRecommendat
     structured: row.structured as CandidateAnalysis["structured"],
     topPositions: row.topPositions as CandidateAnalysis["topPositions"],
     aiInsight: (row.aiInsight ?? null) as CandidateAnalysis["aiInsight"],
+    assignedLearningModules: row.assignedLearningModules as string[],
     createdAt: row.createdAt.toISOString()
   } as CandidateAnalysis));
 
   return filterCandidateRecommendations(candidates, filters).slice(0, 20);
+}
+
+export async function assignCandidateLearningModules(input: {
+  actor: string;
+  candidateId: string;
+  moduleIds: string[];
+}) {
+  const assignedLearningModules = Array.from(new Set(input.moduleIds.map((id) => id.trim()).filter(Boolean)));
+  const db = getDatabase();
+
+  if (!db) {
+    const candidate = memoryCandidates.find((item) => item.id === input.candidateId);
+    if (!candidate) {
+      return null;
+    }
+    candidate.assignedLearningModules = assignedLearningModules;
+    const upload = memoryCandidateUploads.find((item) => item.candidate.id === input.candidateId);
+    if (upload) {
+      upload.candidate.assignedLearningModules = assignedLearningModules;
+    }
+    await appendAuditEvent({
+      actor: input.actor,
+      action: "learning_modules_assigned",
+      entityId: input.candidateId,
+      details: { moduleIds: assignedLearningModules, mode: "local_memory" }
+    });
+    return normalizeCandidateRecommendation(candidate);
+  }
+
+  const rows = await db
+    .select({
+      id: candidateRecommendations.id,
+      candidateName: candidateRecommendations.candidateName,
+      fileName: candidateRecommendations.fileName,
+      storageUrl: candidateRecommendations.storageUrl,
+      structured: candidateRecommendations.structuredResume,
+      topPositions: candidateRecommendations.topPositions,
+      aiInsight: candidateRecommendations.aiInsight,
+      assignedLearningModules: candidateRecommendations.assignedLearningModules,
+      createdAt: candidateRecommendations.createdAt
+    })
+    .from(candidateRecommendations)
+    .where(eq(candidateRecommendations.id, input.candidateId))
+    .limit(1);
+
+  if (!rows.length) {
+    return null;
+  }
+
+  await db
+    .update(candidateRecommendations)
+    .set({ assignedLearningModules })
+    .where(eq(candidateRecommendations.id, input.candidateId));
+
+  await appendAuditEvent({
+    actor: input.actor,
+    action: "learning_modules_assigned",
+    entityId: input.candidateId,
+    details: { moduleIds: assignedLearningModules, mode: "database" }
+  });
+
+  const row = rows[0];
+  return normalizeCandidateRecommendation({
+    id: row.id,
+    candidateName: row.candidateName,
+    fileName: row.fileName,
+    storageUrl: row.storageUrl,
+    structured: row.structured as CandidateAnalysis["structured"],
+    topPositions: row.topPositions as CandidateAnalysis["topPositions"],
+    aiInsight: (row.aiInsight ?? null) as CandidateAnalysis["aiInsight"],
+    assignedLearningModules,
+    createdAt: row.createdAt.toISOString()
+  } as CandidateAnalysis);
 }
 
 export async function getCandidateResumeById(candidateId: string) {

--- a/lib/skillmatch.ts
+++ b/lib/skillmatch.ts
@@ -90,6 +90,7 @@ export type CandidateAnalysis = {
   topPositions: CandidatePositionRecommendation[];
   structured: StructuredResume;
   aiInsight: ResumeAiInsight | null;
+  assignedLearningModules: string[];
   createdAt: string;
 };
 
@@ -541,6 +542,7 @@ export function analyzeCandidateResume(input: {
     topPositions,
     structured: topPositions[0]?.structured ?? extractStructuredResume(input.resumeText),
     aiInsight: null,
+    assignedLearningModules: [],
     createdAt: new Date().toISOString()
   };
 }

--- a/tests/candidate-learning-modules.test.ts
+++ b/tests/candidate-learning-modules.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  assignCandidateLearningModules,
+  listAuditEvents,
+  listCandidateRecommendations,
+  resetCandidateRecommendationsForTests,
+  saveCandidateBatch,
+  type CandidateUploadRecord
+} from "@/lib/db";
+import { analyzeCandidateResume, type CandidateAnalysis } from "@/lib/skillmatch";
+
+function buildUpload(): CandidateUploadRecord {
+  const candidate = analyzeCandidateResume({
+    fileName: "alex-resume.txt",
+    resumeText: "Alex Smith\nJava AWS TypeScript customer obsession. 3 years experience.",
+    storageUrl: "memory://alex-resume.txt"
+  });
+
+  return {
+    candidate,
+    resumeText: "Alex Smith\nJava AWS TypeScript customer obsession. 3 years experience.",
+    duplicateKey: `test:${candidate.id}`,
+    clusterKey: `cluster:${candidate.id}`
+  };
+}
+
+describe("candidate learning module assignments", () => {
+  beforeEach(() => {
+    resetCandidateRecommendationsForTests();
+  });
+
+  it("assigns learning modules to a saved resume", async () => {
+    const upload = buildUpload();
+    const saved = await saveCandidateBatch({ actor: "ld@example.com", uploads: [upload] });
+    const candidate = saved.candidates[0] as CandidateAnalysis;
+
+    const updated = await assignCandidateLearningModules({
+      actor: "ld@example.com",
+      candidateId: candidate.id,
+      moduleIds: ["sde-ii:System Design", "sde-ii:System Design", "sde-ii:AWS"]
+    });
+
+    expect(updated?.assignedLearningModules).toEqual(["sde-ii:System Design", "sde-ii:AWS"]);
+    expect((await listCandidateRecommendations())[0].assignedLearningModules).toEqual([
+      "sde-ii:System Design",
+      "sde-ii:AWS"
+    ]);
+    expect((await listAuditEvents())[0].action).toBe("learning_modules_assigned");
+  });
+
+  it("returns null when the resume cannot be found", async () => {
+    await expect(
+      assignCandidateLearningModules({
+        actor: "ld@example.com",
+        candidateId: "00000000-0000-0000-0000-000000000000",
+        moduleIds: ["sde-ii:AWS"]
+      })
+    ).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds persisted learning-module assignments on candidate resume records.
- Adds an authenticated API route to replace a resume's assigned module list.
- Updates the Learning screen with a resume picker and assign/unassign controls for role learning modules.

## Testing
- npm test -- --run tests/candidate-learning-modules.test.ts
- npm test
- npm run lint
- npm run build

## Notes
- Full Playwright launch was not run because http://127.0.0.1:3000/login was already occupied; the existing app on port 3000 responded successfully.