### PR TITLE
Add PA4 target role E2E validation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,5 +9,6 @@ Use this file to keep a lightweight trail of documentation-impacting changes. Ke
 
 ## Entries
 
+| 2026-05-04 | PA4 MVP validation | Yash Baruah added PA4 MVP validation coverage for target role selection. | `tests/e2e/skillmatch.spec.ts` |
 | 2026-05-02 | UI / front-end | Global UI aligned with ui-ux-pro-max “Trust & Authority” / enterprise slate: slate neutrals and WCAG-friendly muted text, `--sidebar-bg` and inset amber active nav, 200 ms motion tokens, `prefers-reduced-motion`, and `focus-visible` rings (sky default, amber on primaries and header search via `:focus-within`). Inter applied on `<body>` with `next/font`. Also includes sidebar width, concept grid spacing, and prior dashboard/auth polish. | `app/globals.css`, `app/layout.tsx`, `app/dashboard.tsx` |
 | 2026-05-02 | Docs process | Added repo-owned documentation workflow, changelog guidance, PR checklist prompts, and artifact organization rules for source vs generated docs. | `README.md`, `docs/README.md`, `docs/source/README.md`, `docs/generated/README.md`, `.github/pull_request_template.md` |

--- a/tests/e2e/skillmatch.spec.ts
+++ b/tests/e2e/skillmatch.spec.ts
@@ -92,6 +92,35 @@ test("requires credential sign-in, uploads a PDF resume, and ranks positions", a
   await expect(page.locator(".skill-gap-chart").getByText("system design")).toBeVisible();
 });
 
+test("updates dashboard match context when the target role changes after analysis", async ({ page }) => {
+  const notice = page.locator(".notice");
+  const scoreRing = page.locator(".overview-panel [aria-label^='Match score']");
+  const skillGapChart = page.locator(".skill-gap-chart");
+  const targetRole = page.getByRole("combobox", { name: /target role/i });
+
+  await page.context().clearCookies();
+  await signInDemoRecruiter(page);
+
+  await pickDashboardResume(page, resumePath);
+  await page.getByRole("button", { name: /run skillmatch analysis/i }).click();
+  await expect(notice).toHaveText(/Processed 1 resume/);
+
+  await expect(targetRole).toHaveValue("sde-ii");
+  await expect(page.getByLabel("Software Development Engineer II skill coverage chart")).toBeVisible();
+  await expect(skillGapChart.getByText("system design")).toBeVisible();
+  await expect(scoreRing).toHaveAttribute("aria-label", /Match score \d+%/);
+  const originalScore = await scoreRing.getAttribute("aria-label");
+
+  await targetRole.selectOption({ label: "Cloud Support Associate" });
+
+  await expect(targetRole).toHaveValue("cloud-support");
+  await expect(page.getByText("Job Family: Cloud Operations")).toBeVisible();
+  await expect(page.getByLabel("Cloud Support Associate skill coverage chart")).toBeVisible();
+  await expect(skillGapChart.getByText("customer support")).toBeVisible();
+  await expect(skillGapChart.getByText("system design")).toHaveCount(0);
+  await expect(scoreRing).not.toHaveAttribute("aria-label", originalScore ?? "");
+});
+
 test("shows duplicate advisory when uploading the same resume twice in sequence", async ({ page }) => {
   test.skip(
     !hasMemoryIsolation,


### PR DESCRIPTION
## Summary
- Added a Playwright E2E test for the PA4 MVP target role selection flow.
- The test logs in, uploads/analyzes the sample resume, changes the target role to Cloud Support Associate, and verifies that the dashboard updates.
- Added a short changelog entry for Yash Baruah's PA4 validation contribution.

## Testing
- npm run lint
- npm test
- npm run build
- npm run test:e2e