### PR TITLE
updated the website

### DIFF
--- a/app/dashboard.tsx
+++ b/app/dashboard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { CSSProperties, FormEvent } from "react";
+import type { CSSProperties, FormEvent, KeyboardEvent } from "react";
 import {
   Activity,
   AlertTriangle,
@@ -18,13 +18,11 @@ import {
   Settings,
   ShieldCheck,
   SlidersHorizontal,
-  Sparkles,
-  Target,
   Trash2,
   UploadCloud,
   Users,
   X,
-  type LucideIcon
+  type LucideIcon,
 } from "lucide-react";
 import { roles, type RoleRequirement } from "@/lib/seed-data";
 import type { SessionUser } from "@/lib/auth-model";
@@ -32,7 +30,6 @@ import type {
   AnalysisRecord,
   AuditEvent,
   CandidateDuplicateWarning,
-  SavedTargetRole,
 } from "@/lib/db";
 import type { CandidateAnalysis } from "@/lib/skillmatch";
 
@@ -51,7 +48,13 @@ type SkillGapChartItem = {
   coverage: number;
 };
 
-type View = "dashboard" | "analyses" | "learning" | "workforce" | "audit" | "settings";
+type View =
+  | "dashboard"
+  | "analyses"
+  | "learning"
+  | "workforce"
+  | "audit"
+  | "settings";
 
 const navItems: Array<{ id: View; label: string; icon: LucideIcon }> = [
   { id: "dashboard", label: "Dashboard", icon: LayoutDashboard },
@@ -59,14 +62,76 @@ const navItems: Array<{ id: View; label: string; icon: LucideIcon }> = [
   { id: "learning", label: "Learning", icon: BookOpen },
   { id: "workforce", label: "Workforce", icon: Users },
   { id: "audit", label: "Audit Log", icon: ShieldCheck },
-  { id: "settings", label: "Settings", icon: Settings }
+  { id: "settings", label: "Settings", icon: Settings },
 ];
+
+const technologyOptions = Array.from(
+  new Set(
+    roles.flatMap((role) => [...role.requiredSkills, ...role.preferredSkills]),
+  ),
+).sort((a, b) =>
+  formatTechnologyLabel(a).localeCompare(formatTechnologyLabel(b)),
+);
+
+const educationOptions = [
+  "High school",
+  "Associate",
+  "Bachelor",
+  "Master",
+  "MBA",
+  "PhD",
+  "Bootcamp",
+  "Certification",
+];
+
+function formatTechnologyLabel(value: string) {
+  const specialLabels: Record<string, string> = {
+    "api design": "API Design",
+    aws: "AWS",
+    "ci cd": "CI/CD",
+    docker: "Docker",
+    excel: "Excel",
+    git: "Git",
+    java: "Java",
+    javascript: "JavaScript",
+    kubernetes: "Kubernetes",
+    node: "Node.js",
+    postgresql: "PostgreSQL",
+    python: "Python",
+    react: "React",
+    "rest api": "REST API",
+    sql: "SQL",
+    tableau: "Tableau",
+    typescript: "TypeScript",
+  };
+  return (
+    specialLabels[value.toLowerCase()] ??
+    value.replace(/\b\w/g, (letter) => letter.toUpperCase())
+  );
+}
+
+function parseFilterValues(value: string) {
+  return Array.from(
+    new Set(
+      value
+        .split(",")
+        .map((item) => item.trim())
+        .filter(Boolean),
+    ),
+  );
+}
+
+function serializeFilterValues(values: string[]) {
+  return values.join(", ");
+}
 
 function fileKey(file: File) {
   return `${file.name}-${file.size}-${file.lastModified}`;
 }
 
-function candidateHasStoredResumeFile(candidate: Pick<CandidateAnalysis, "storageUrl" | "fileName">) {
+function candidateHasStoredResumeFile(
+  candidate: Pick<CandidateAnalysis, "storageUrl" | "fileName">,
+) {
   return Boolean(candidate.storageUrl?.trim() && candidate.fileName?.trim());
 }
 
@@ -74,7 +139,11 @@ function learningModuleId(roleId: string, skill: string) {
   return `${roleId}:${skill}`;
 }
 
-function CandidateResumeFileLinks({ candidate }: { candidate: CandidateAnalysis }) {
+function CandidateResumeFileLinks({
+  candidate,
+}: {
+  candidate: CandidateAnalysis;
+}) {
   if (!candidateHasStoredResumeFile(candidate)) {
     return null;
   }
@@ -112,14 +181,22 @@ export default function Dashboard({
   const [files, setFiles] = useState<File[]>([]);
   const [candidates, setCandidates] = useState<CandidateAnalysis[]>([]);
   const [analyses, setAnalyses] = useState<AnalysisRecord[]>([]);
-  const [savedRoles, setSavedRoles] = useState<SavedTargetRole[]>([]);
   const [auditEvents, setAuditEvents] = useState<AuditEvent[]>([]);
   const [failures, setFailures] = useState<UploadResponse["failures"]>([]);
-  const [uploadDuplicateWarnings, setUploadDuplicateWarnings] = useState<CandidateDuplicateWarning[]>([]);
-  const [overrideCandidate, setOverrideCandidate] = useState<CandidateAnalysis | null>(null);
+  const [uploadDuplicateWarnings, setUploadDuplicateWarnings] = useState<
+    CandidateDuplicateWarning[]
+  >([]);
+  const [overrideCandidate, setOverrideCandidate] =
+    useState<CandidateAnalysis | null>(null);
   const [selectedCandidateId, setSelectedCandidateId] = useState<string>("");
-  const [selectedLearningCandidateId, setSelectedLearningCandidateId] = useState<string>("");
-  const [learningAssignmentStatus, setLearningAssignmentStatus] = useState<"idle" | "saving">("idle");
+  const [selectedLearningCandidateId, setSelectedLearningCandidateId] =
+    useState<string>("");
+  const [learningRoleOverrides, setLearningRoleOverrides] = useState<
+    Record<string, string>
+  >({});
+  const [learningAssignmentStatus, setLearningAssignmentStatus] = useState<
+    "idle" | "saving"
+  >("idle");
   const [isUploading, setIsUploading] = useState(false);
   const [notice, setNotice] = useState("");
   const [analysisHistoryStatus, setAnalysisHistoryStatus] = useState<
@@ -130,6 +207,16 @@ export default function Dashboard({
   const [educationFilter, setEducationFilter] = useState("");
   const [locationFilter, setLocationFilter] = useState("");
   const [minYearsFilter, setMinYearsFilter] = useState("");
+  const [settingsProfile, setSettingsProfile] = useState({
+    displayName: user.name,
+    email: user.email,
+    team: "Learning Development",
+    region: "North America",
+    defaultRoleId: roleId,
+    reviewThreshold: "70",
+    weeklyDigest: true,
+    auditCopy: user.role === "system_admin",
+  });
   const serverFiltersRef = useRef({
     skill: "",
     education: "",
@@ -147,13 +234,31 @@ export default function Dashboard({
   }, [educationFilter, locationFilter, minYearsFilter, skillFilter]);
 
   const selectedRole = roles.find((role) => role.id === roleId) ?? roles[0];
-  const selectedCandidate = candidates.find((candidate) => candidate.id === selectedCandidateId) ?? candidates[0];
+  const selectedCandidate =
+    candidates.find((candidate) => candidate.id === selectedCandidateId) ??
+    candidates[0];
   const selectedLearningCandidate =
-    candidates.find((candidate) => candidate.id === selectedLearningCandidateId) ?? selectedCandidate;
-  const selectedRoleMatch = selectedCandidate?.topPositions.find((item) => item.role.id === roleId);
-  const bestRecommendation = selectedRoleMatch ?? selectedCandidate?.topPositions[0];
+    candidates.find(
+      (candidate) => candidate.id === selectedLearningCandidateId,
+    ) ?? selectedCandidate;
+  const selectedLearningRoleId =
+    (selectedLearningCandidate
+      ? learningRoleOverrides[selectedLearningCandidate.id]
+      : undefined) ??
+    selectedLearningCandidate?.topPositions[0]?.role.id ??
+    roles[0].id;
+  const selectedLearningRole =
+    roles.find((role) => role.id === selectedLearningRoleId) ?? roles[0];
+  const selectedLearningMatch =
+    selectedLearningCandidate?.topPositions.find(
+      (item) => item.role.id === selectedLearningRole.id,
+    ) ?? selectedLearningCandidate?.topPositions[0];
+  const selectedRoleMatch = selectedCandidate?.topPositions.find(
+    (item) => item.role.id === roleId,
+  );
+  const bestRecommendation =
+    selectedRoleMatch ?? selectedCandidate?.topPositions[0];
   const selectedResult = selectedRoleMatch ?? bestRecommendation;
-  const savedCurrentRole = savedRoles.find((role) => role.roleId === roleId);
 
   const workforceGaps = useMemo(() => {
     const counts = new Map<string, number>();
@@ -167,6 +272,36 @@ export default function Dashboard({
       .slice(0, 8);
   }, [candidates]);
 
+  const dashboardStats = useMemo(() => {
+    const roleCounts = new Map<string, number>();
+    let scoreTotal = 0;
+    let scoreCount = 0;
+    let assignedModules = 0;
+
+    candidates.forEach((candidate) => {
+      const bestRole = candidate.topPositions[0];
+      if (bestRole) {
+        roleCounts.set(
+          bestRole.role.title,
+          (roleCounts.get(bestRole.role.title) ?? 0) + 1,
+        );
+        scoreTotal += bestRole.score;
+        scoreCount += 1;
+      }
+      assignedModules += candidate.assignedLearningModules?.length ?? 0;
+    });
+
+    return {
+      resumeCount: candidates.length,
+      averageMatch: scoreCount ? Math.round(scoreTotal / scoreCount) : 0,
+      assignedModules,
+      activeRoleFamilies: roles.length,
+      roleDistribution: Array.from(roleCounts.entries())
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 4),
+    };
+  }, [candidates]);
+
   const workforceGapMeterMax = Math.max(files.length, candidates.length, 5);
 
   const skillGapChartItems = useMemo<SkillGapChartItem[]>(() => {
@@ -175,10 +310,16 @@ export default function Dashboard({
     }
 
     const matchedSkills = new Set(selectedResult.matchedSkills);
-    const missingSkills = new Map(selectedResult.missingSkills.map((gap) => [gap.skill, gap]));
+    const missingSkills = new Map(
+      selectedResult.missingSkills.map((gap) => [gap.skill, gap]),
+    );
 
-    return [...selectedRole.requiredSkills, ...selectedRole.preferredSkills].map((skill) => {
-      const source: SkillGapChartItem["source"] = selectedRole.requiredSkills.includes(skill) ? "required" : "preferred";
+    return [
+      ...selectedRole.requiredSkills,
+      ...selectedRole.preferredSkills,
+    ].map((skill) => {
+      const source: SkillGapChartItem["source"] =
+        selectedRole.requiredSkills.includes(skill) ? "required" : "preferred";
       const isMatched = matchedSkills.has(skill);
       const missingGap = missingSkills.get(skill);
 
@@ -186,8 +327,10 @@ export default function Dashboard({
         skill,
         source,
         status: isMatched ? "matched" : "gap",
-        importance: missingGap?.importance ?? (source === "required" ? "critical" : "important"),
-        coverage: isMatched ? 100 : source === "required" ? 32 : 56
+        importance:
+          missingGap?.importance ??
+          (source === "required" ? "critical" : "important"),
+        coverage: isMatched ? 100 : source === "required" ? 32 : 56,
       };
     });
   }, [selectedRole, selectedResult]);
@@ -195,15 +338,21 @@ export default function Dashboard({
   const filteredCandidates = candidates.filter((candidate) =>
     `${candidate.candidateName} ${candidate.fileName} ${candidate.topPositions[0]?.role.title ?? ""}`
       .toLowerCase()
-      .includes(query.toLowerCase())
+      .includes(query.toLowerCase()),
   );
 
   const hasActiveServerCandidateFilters = Boolean(
-    skillFilter.trim() || educationFilter.trim() || locationFilter.trim() || minYearsFilter.trim()
+    skillFilter.trim() ||
+    educationFilter.trim() ||
+    locationFilter.trim() ||
+    minYearsFilter.trim(),
   );
 
   const refreshRecords = useCallback(
-    async (options?: { skipCandidates?: boolean; forceEmptyCandidateFilters?: boolean }) => {
+    async (options?: {
+      skipCandidates?: boolean;
+      forceEmptyCandidateFilters?: boolean;
+    }) => {
       const candidateParams = new URLSearchParams();
       const useServerFilters = !options?.forceEmptyCandidateFilters;
       if (useServerFilters) {
@@ -223,20 +372,29 @@ export default function Dashboard({
         }
       }
 
-      const candidateQuery = candidateParams.size ? `?${candidateParams.toString()}` : "";
-      const auditRequest = user.role === "system_admin" ? fetch("/api/audit") : Promise.resolve(null);
+      const candidateQuery = candidateParams.size
+        ? `?${candidateParams.toString()}`
+        : "";
+      const auditRequest =
+        user.role === "system_admin"
+          ? fetch("/api/audit")
+          : Promise.resolve(null);
 
       const skipCandidates = Boolean(options?.skipCandidates);
-      const [candidateResponse, analysisResponse, savedRolesResponse, auditResponse] = await Promise.all([
-        skipCandidates ? Promise.resolve(null) : fetch(`/api/candidates${candidateQuery}`),
-        fetch("/api/analyses"),
-        fetch("/api/saved-roles"),
-        auditRequest
-      ]);
+      const [candidateResponse, analysisResponse, auditResponse] =
+        await Promise.all([
+          skipCandidates
+            ? Promise.resolve(null)
+            : fetch(`/api/candidates${candidateQuery}`),
+          fetch("/api/analyses"),
+          auditRequest,
+        ]);
 
       if (candidateResponse) {
         if (candidateResponse.ok) {
-          const payload = (await candidateResponse.json()) as { candidates: CandidateAnalysis[] };
+          const payload = (await candidateResponse.json()) as {
+            candidates: CandidateAnalysis[];
+          };
           setCandidates(payload.candidates);
           setSelectedCandidateId((current) => {
             const ids = new Set(payload.candidates.map((c) => c.id));
@@ -259,15 +417,22 @@ export default function Dashboard({
             return payload.candidates[0]!.id;
           });
         } else {
-          const payload = (await candidateResponse.json().catch(() => ({}))) as {
+          const payload = (await candidateResponse
+            .json()
+            .catch(() => ({}))) as {
             error?: string;
           };
-          setNotice(payload.error ?? `Could not load candidates (HTTP ${candidateResponse.status}).`);
+          setNotice(
+            payload.error ??
+              `Could not load candidates (HTTP ${candidateResponse.status}).`,
+          );
         }
       }
 
       if (analysisResponse.ok) {
-        const payload = (await analysisResponse.json()) as { analyses: AnalysisRecord[] };
+        const payload = (await analysisResponse.json()) as {
+          analyses: AnalysisRecord[];
+        };
         setAnalyses(payload.analyses);
         setAnalysisHistoryStatus("ready");
       } else if (analysisResponse.status === 403) {
@@ -277,23 +442,14 @@ export default function Dashboard({
         setAnalysisHistoryStatus("error");
       }
 
-      if (savedRolesResponse.ok) {
-        const payload = (await savedRolesResponse.json()) as { savedRoles: SavedTargetRole[] };
-        setSavedRoles(payload.savedRoles);
-      } else {
-        const payload = (await savedRolesResponse.json().catch(() => ({}))) as {
-          error?: string;
-        };
-        setNotice(payload.error ?? `Could not load saved roles (HTTP ${savedRolesResponse.status}).`);
-      }
-
       if (auditResponse?.ok) {
-        const payload = (await auditResponse.json()) as { events: AuditEvent[] };
+        const payload = (await auditResponse.json()) as {
+          events: AuditEvent[];
+        };
         setAuditEvents(payload.events);
       }
-
     },
-    [educationFilter, locationFilter, minYearsFilter, skillFilter, user.role]
+    [educationFilter, locationFilter, minYearsFilter, skillFilter, user.role],
   );
 
   useEffect(() => {
@@ -305,7 +461,9 @@ export default function Dashboard({
     if (!fileList) {
       return;
     }
-    const nextFiles = Array.from(fileList).filter((file) => /\.(pdf|docx|txt|zip)$/i.test(file.name));
+    const nextFiles = Array.from(fileList).filter((file) =>
+      /\.(pdf|docx|txt|zip)$/i.test(file.name),
+    );
     setFiles((current) => {
       const queued = new Set(current.map(fileKey));
       const uniqueFiles = nextFiles.filter((file) => {
@@ -328,7 +486,9 @@ export default function Dashboard({
       __skillmatchE2eSyncQueuedFilesFromInput?: () => void;
     };
     win.__skillmatchE2eSyncQueuedFilesFromInput = () => {
-      const input = document.querySelector<HTMLInputElement>(".upload-panel input[type=file]");
+      const input = document.querySelector<HTMLInputElement>(
+        ".upload-panel input[type=file]",
+      );
       if (!input?.files?.length) {
         return;
       }
@@ -341,7 +501,9 @@ export default function Dashboard({
 
   function removeFile(fileToRemove: File) {
     const removeKey = fileKey(fileToRemove);
-    setFiles((current) => current.filter((file) => fileKey(file) !== removeKey));
+    setFiles((current) =>
+      current.filter((file) => fileKey(file) !== removeKey),
+    );
   }
 
   function clearFiles() {
@@ -377,14 +539,16 @@ export default function Dashboard({
         try {
           payload = await response.json();
         } catch {
-          setNotice(`Upload failed (${response.status}). The server returned invalid JSON.`);
+          setNotice(
+            `Upload failed (${response.status}). The server returned invalid JSON.`,
+          );
           return;
         }
       } else {
         const text = await response.text();
         if (/__next_error__|DOCTYPE/i.test(text)) {
           setNotice(
-            `Upload failed (${response.status}). The app returned an HTML error page instead of JSON — check server logs (storage, database, or migrations).`
+            `Upload failed (${response.status}). The app returned an HTML error page instead of JSON — check server logs (storage, database, or migrations).`,
           );
           return;
         }
@@ -403,7 +567,10 @@ export default function Dashboard({
           errBody.hint === "migrate"
             ? " Run database migrations if you use Neon/Postgres."
             : "";
-        setNotice((errBody.error ?? `Upload failed (${response.status}).`) + migrateHelp);
+        setNotice(
+          (errBody.error ?? `Upload failed (${response.status}).`) +
+            migrateHelp,
+        );
         return;
       }
 
@@ -438,12 +605,17 @@ export default function Dashboard({
       const prevFilters = serverFiltersRef.current;
       const hadServerFilters = Boolean(
         prevFilters.skill.trim() ||
-          prevFilters.education.trim() ||
-          prevFilters.location.trim() ||
-          prevFilters.minYears.trim(),
+        prevFilters.education.trim() ||
+        prevFilters.location.trim() ||
+        prevFilters.minYears.trim(),
       );
-      if (uploadPayload.candidates.length > 0 && !persistWarn && hadServerFilters) {
-        message += " Candidate filters were cleared so new uploads stay visible under Analyses.";
+      if (
+        uploadPayload.candidates.length > 0 &&
+        !persistWarn &&
+        hadServerFilters
+      ) {
+        message +=
+          " Candidate filters were cleared so new uploads stay visible under Analyses.";
         setSkillFilter("");
         setEducationFilter("");
         setLocationFilter("");
@@ -463,44 +635,12 @@ export default function Dashboard({
         void refreshRecords({ skipCandidates: Boolean(persistWarn) });
       }
     } catch (error) {
-      setNotice(error instanceof Error ? error.message : "Upload failed unexpectedly.");
+      setNotice(
+        error instanceof Error ? error.message : "Upload failed unexpectedly.",
+      );
     } finally {
       setIsUploading(false);
     }
-  }
-
-  async function saveCurrentTargetRole() {
-    const response = await fetch("/api/saved-roles", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        roleId,
-        targetScore: 80,
-        currentScore: selectedResult?.score ?? null,
-        matchedSkills,
-        missingSkills: missingSkills.map((gap) => gap.skill)
-      })
-    });
-
-    if (!response.ok) {
-      const payload = (await response.json().catch(() => ({}))) as { error?: string };
-      setNotice(payload.error ?? "Could not bookmark this role for Learning.");
-      return;
-    }
-
-    const payload = (await response.json()) as { savedRole: SavedTargetRole };
-    setSavedRoles((current) => [payload.savedRole, ...current.filter((role) => role.id !== payload.savedRole.id)]);
-    setNotice(`Pinned "${selectedRole.title}" for Learning. Candidate analyses stay under Analyses.`);
-  }
-
-  async function removeSavedRole(id: string) {
-    const response = await fetch(`/api/saved-roles?id=${encodeURIComponent(id)}`, { method: "DELETE" });
-    if (response.ok) {
-      setSavedRoles((current) => current.filter((role) => role.id !== id));
-      return;
-    }
-    const payload = (await response.json().catch(() => ({}))) as { error?: string };
-    setNotice(payload.error ?? "Could not remove this bookmark. Try again.");
   }
 
   async function assignLearningModule(moduleId: string, assigned: boolean) {
@@ -509,7 +649,9 @@ export default function Dashboard({
       return;
     }
 
-    const currentModules = new Set(selectedLearningCandidate.assignedLearningModules ?? []);
+    const currentModules = new Set(
+      selectedLearningCandidate.assignedLearningModules ?? [],
+    );
     if (assigned) {
       currentModules.add(moduleId);
     } else {
@@ -517,22 +659,33 @@ export default function Dashboard({
     }
 
     setLearningAssignmentStatus("saving");
-    const response = await fetch(`/api/candidates/${selectedLearningCandidate.id}/learning-modules`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ moduleIds: Array.from(currentModules) })
-    });
+    const response = await fetch(
+      `/api/candidates/${selectedLearningCandidate.id}/learning-modules`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ moduleIds: Array.from(currentModules) }),
+      },
+    );
 
     setLearningAssignmentStatus("idle");
     if (!response.ok) {
-      const payload = (await response.json().catch(() => ({}))) as { error?: string };
+      const payload = (await response.json().catch(() => ({}))) as {
+        error?: string;
+      };
       setNotice(payload.error ?? "Could not update learning assignments.");
       return;
     }
 
     const payload = (await response.json()) as { candidate: CandidateAnalysis };
-    setCandidates((current) => current.map((candidate) => (candidate.id === payload.candidate.id ? payload.candidate : candidate)));
-    setNotice(`Updated learning modules for ${payload.candidate.candidateName}.`);
+    setCandidates((current) =>
+      current.map((candidate) =>
+        candidate.id === payload.candidate.id ? payload.candidate : candidate,
+      ),
+    );
+    setNotice(
+      `Updated learning modules for ${payload.candidate.candidateName}.`,
+    );
   }
 
   async function logout() {
@@ -543,7 +696,9 @@ export default function Dashboard({
   const matchedSkills = selectedResult?.matchedSkills ?? [];
   const missingSkills = selectedResult?.missingSkills ?? [];
   const userCanSubmitRecruiterOverride =
-    user.role === "recruiter" || user.role === "hiring_manager" || user.role === "system_admin";
+    user.role === "recruiter" ||
+    user.role === "hiring_manager" ||
+    user.role === "system_admin";
 
   return (
     <main className="product-shell">
@@ -554,30 +709,13 @@ export default function Dashboard({
               <h1>SkillMatch AI</h1>
               <p className="brand-tagline">Resume analysis and role fit</p>
             </div>
-            <label className="role-context">
-              Target role
-              <select value={roleId} onChange={(event) => setRoleId(event.target.value)}>
-                {roles.map((role) => (
-                  <option key={role.id} value={role.id}>
-                    {role.title}
-                  </option>
-                ))}
-              </select>
-            </label>
           </div>
           <div className="header-actions">
-            <button
-              className="icon-text-button"
-              type="button"
-              disabled={isUploading}
-              title={isUploading ? "Wait for upload to finish before refreshing." : "Reload candidates, bookmarks, and analysis history"}
-              onClick={() => void refreshRecords()}
-            >
-              Refresh data
-            </button>
             <span className="session-meta">
               {user.name}
-              <span className="session-meta-role">{user.role.replace("_", " ")}</span>
+              <span className="session-meta-role">
+                {user.role.replace("_", " ")}
+              </span>
             </span>
             <button className="icon-text-button" type="button" onClick={logout}>
               <LogOut aria-hidden="true" />
@@ -604,469 +742,716 @@ export default function Dashboard({
         </nav>
 
         <section className="main-product">
-
-        {view === "dashboard" ? (
-          <>
-            <section className="concept-grid">
-              <section className="concept-panel upload-panel">
-                <h2>Upload resumes</h2>
-                <div
-                  className="drop-zone"
-                  onDrop={(event) => {
-                    event.preventDefault();
-                    addFiles(event.dataTransfer.files);
-                  }}
-                  onDragOver={(event) => event.preventDefault()}
-                >
-                  <UploadCloud aria-hidden="true" />
-                  <strong>Drop PDF, DOCX, TXT, or ZIP resumes here</strong>
-                  <span>or click to browse</span>
-                  <input
-                    aria-label="Upload resume files"
-                    type="file"
-                    multiple
-                    accept=".pdf,.docx,.txt,.zip,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,text/plain,application/zip,application/x-zip-compressed"
-                    onChange={(event) => {
-                      addFiles(event.target.files);
-                      event.currentTarget.value = "";
-                    }}
-                  />
-                </div>
-                <div className="queue-header">
-                  <span>{files.length ? `${files.length} selected` : "No resumes selected"}</span>
-                  <button className="queue-clear-button" type="button" onClick={clearFiles} disabled={!files.length || isUploading}>
-                    <Trash2 aria-hidden="true" />
-                    Clear all
-                  </button>
-                </div>
-                <ul className="file-list">
-                  {files.map((file) => (
-                    <li key={fileKey(file)}>
-                      <CheckCircle2 aria-hidden="true" />
-                      <span>{file.name}</span>
-                      <small>{Math.round(file.size / 1024)} KB</small>
-                      <button
-                        className="queue-icon-button"
-                        type="button"
-                        onClick={() => removeFile(file)}
-                        disabled={isUploading}
-                        aria-label={`Remove ${file.name}`}
-                        title={`Remove ${file.name}`}
-                      >
-                        <X aria-hidden="true" />
-                      </button>
-                    </li>
-                  ))}
-                </ul>
-                <div className="role-facts">
-                  <h3>Role context</h3>
-                  <p>Job Family: {selectedRole.family}</p>
-                  <p>Business Unit: {selectedRole.department}</p>
-                  <p>Level: {selectedRole.level}</p>
-                  <p>
-                    Experience: {selectedRole.minimumYearsExperience} to {selectedRole.idealYearsExperience}+ years
-                  </p>
-                  <p>
-                    Certifications:{" "}
-                    {selectedRole.requiredCertifications.concat(selectedRole.preferredCertifications).join(", ") || "None specified"}
-                  </p>
-                  <p>
-                    Soft skills:{" "}
-                    {selectedRole.requiredSoftSkills.concat(selectedRole.preferredSoftSkills).join(", ")}
-                  </p>
-                </div>
-                {notice ? <p className="notice">{notice}</p> : null}
-                {failures.map((failure) => (
-                  <p className="error-message" key={failure.fileName}>
-                    {failure.fileName}: {failure.error}
-                  </p>
-                ))}
-                {uploadDuplicateWarnings.length > 0 ? (
+          {view === "dashboard" ? (
+            <>
+              <section className="concept-grid dashboard-workbench">
+                <section className="concept-panel upload-panel dashboard-left-rail">
+                  <h2>Upload resumes</h2>
                   <div
-                    data-testid="upload-duplicate-advisory"
-                    className="rounded-lg border border-border-strong bg-brand-light px-3 py-2.5 text-[13px] text-ink"
-                    role="region"
-                    aria-label="Duplicate resume notices"
+                    className="drop-zone"
+                    onDrop={(event) => {
+                      event.preventDefault();
+                      addFiles(event.dataTransfer.files);
+                    }}
+                    onDragOver={(event) => event.preventDefault()}
                   >
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <strong className="font-semibold">Duplicate / cluster notices</strong>
-                        <span className="mt-1 block font-normal leading-snug text-muted">
-                          These files matched an existing uploaded résumé or another file in this run. Ranking did not store
-                          a new row until you resolve overlaps.
+                    <UploadCloud aria-hidden="true" />
+                    <strong>Drop PDF, DOCX, TXT, or ZIP resumes here</strong>
+                    <span>or click to browse</span>
+                    <input
+                      aria-label="Upload resume files"
+                      type="file"
+                      multiple
+                      accept=".pdf,.docx,.txt,.zip,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,text/plain,application/zip,application/x-zip-compressed"
+                      onChange={(event) => {
+                        addFiles(event.target.files);
+                        event.currentTarget.value = "";
+                      }}
+                    />
+                  </div>
+                  <div className="queue-header">
+                    <span>
+                      {files.length
+                        ? `${files.length} selected`
+                        : "No resumes selected"}
+                    </span>
+                    <button
+                      className="queue-clear-button"
+                      type="button"
+                      onClick={clearFiles}
+                      disabled={!files.length || isUploading}
+                    >
+                      <Trash2 aria-hidden="true" />
+                      Clear all
+                    </button>
+                  </div>
+                  <ul className="file-list">
+                    {files.map((file) => (
+                      <li key={fileKey(file)}>
+                        <CheckCircle2 aria-hidden="true" />
+                        <span>{file.name}</span>
+                        <small>{Math.round(file.size / 1024)} KB</small>
+                        <button
+                          className="queue-icon-button"
+                          type="button"
+                          onClick={() => removeFile(file)}
+                          disabled={isUploading}
+                          aria-label={`Remove ${file.name}`}
+                          title={`Remove ${file.name}`}
+                        >
+                          <X aria-hidden="true" />
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                  <div className="role-facts">
+                    <label className="role-context">
+                      Comparison role
+                      <select
+                        value={roleId}
+                        onChange={(event) => setRoleId(event.target.value)}
+                      >
+                        {roles.map((role) => (
+                          <option key={role.id} value={role.id}>
+                            {role.title}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                    <h3>Role context</h3>
+                    <p>Job Family: {selectedRole.family}</p>
+                    <p>Business Unit: {selectedRole.department}</p>
+                    <p>Level: {selectedRole.level}</p>
+                    <p>
+                      Experience: {selectedRole.minimumYearsExperience} to{" "}
+                      {selectedRole.idealYearsExperience}+ years
+                    </p>
+                    <p>
+                      Certifications:{" "}
+                      {selectedRole.requiredCertifications
+                        .concat(selectedRole.preferredCertifications)
+                        .join(", ") || "None specified"}
+                    </p>
+                    <p>
+                      Soft skills:{" "}
+                      {selectedRole.requiredSoftSkills
+                        .concat(selectedRole.preferredSoftSkills)
+                        .join(", ")}
+                    </p>
+                  </div>
+                  {notice ? <p className="notice">{notice}</p> : null}
+                  {failures.map((failure) => (
+                    <p className="error-message" key={failure.fileName}>
+                      {failure.fileName}: {failure.error}
+                    </p>
+                  ))}
+                  {uploadDuplicateWarnings.length > 0 ? (
+                    <div
+                      data-testid="upload-duplicate-advisory"
+                      className="rounded-lg border border-border-strong bg-brand-light px-3 py-2.5 text-[13px] text-ink"
+                      role="region"
+                      aria-label="Duplicate resume notices"
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <strong className="font-semibold">
+                            Duplicate / cluster notices
+                          </strong>
+                          <span className="mt-1 block font-normal leading-snug text-muted">
+                            These files matched an existing uploaded résumé or
+                            another file in this run. Ranking did not store a
+                            new row until you resolve overlaps.
+                          </span>
+                        </div>
+                        <button
+                          type="button"
+                          className="queue-icon-button shrink-0"
+                          aria-label="Dismiss duplicate notices"
+                          title="Dismiss"
+                          onClick={() => setUploadDuplicateWarnings([])}
+                        >
+                          <X aria-hidden={true} />
+                        </button>
+                      </div>
+                      <ul className="upload-duplicate-list mt-3 list-none space-y-1.5 p-0 font-medium">
+                        {uploadDuplicateWarnings.map((dup) => (
+                          <li
+                            key={`${dup.fileName}:${dup.duplicateKey}:${dup.clusterKey}:${dup.source}`}
+                          >
+                            <span className="text-ink">{dup.fileName}</span>
+                            <span className="text-muted"> — {dup.message}</span>
+                            {dup.matchedFileName ? (
+                              <span className="text-muted">
+                                {" "}
+                                ({dup.matchedFileName})
+                              </span>
+                            ) : null}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ) : null}
+                  <button
+                    className="run-button"
+                    onClick={uploadResumes}
+                    disabled={isUploading || !files.length}
+                    title={
+                      !files.length
+                        ? "Add at least one résumé file (PDF, DOCX, TXT, or ZIP) to run analysis."
+                        : undefined
+                    }
+                  >
+                    <SlidersHorizontal aria-hidden="true" />
+                    {isUploading
+                      ? "Processing resumes..."
+                      : "Run SkillMatch Analysis"}
+                  </button>
+                  <RecommendationPanel candidate={selectedCandidate} compact />
+                </section>
+
+                <section className="concept-panel overview-panel dashboard-main-panel">
+                  <div className="panel-heading">
+                    <h2>Skill Match Overview</h2>
+                    {selectedCandidate ? (
+                      <span className="overview-panel-candidate-heading">
+                        <span>{selectedCandidate.candidateName}</span>
+                        <CandidateResumeFileLinks
+                          candidate={selectedCandidate}
+                        />
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="overview-content">
+                    <div className="overview-summary">
+                      <div
+                        className={`score-column${selectedResult ? "" : " is-empty"}`}
+                      >
+                        <div
+                          className="score-ring large"
+                          style={
+                            {
+                              "--score": `${selectedResult?.score ?? 0}%`,
+                            } as CSSProperties
+                          }
+                          aria-label={
+                            selectedResult
+                              ? `Match score ${selectedResult.score}%`
+                              : "No match score yet"
+                          }
+                        >
+                          <strong>
+                            {selectedResult ? `${selectedResult.score}%` : "—"}
+                          </strong>
+                        </div>
+                        <strong>Overall Match</strong>
+                        <span>
+                          {selectedResult
+                            ? selectedRole.title
+                            : "Upload resumes to rank positions"}
                         </span>
                       </div>
+                      <SkillList
+                        title="Top Matched Skills"
+                        items={matchedSkills.slice(0, 8)}
+                      />
+                      <ReadinessSignals result={selectedResult} />
+                      <GapList gaps={missingSkills.slice(0, 8)} />
+                    </div>
+                    <DashboardStatsPanel stats={dashboardStats} />
+                    <DashboardGapPanel gaps={workforceGaps} />
+                    <RoleSkillGapChart
+                      candidateName={selectedCandidate?.candidateName}
+                      items={skillGapChartItems}
+                      roleTitle={selectedRole.title}
+                    />
+                  </div>
+                </section>
+
+                <aside className="right-stack dashboard-right-rail">
+                  <RecentCandidates
+                    candidates={candidates}
+                    onSelect={setSelectedCandidateId}
+                  />
+                </aside>
+              </section>
+            </>
+          ) : null}
+
+          {view === "analyses" ? (
+            <section className="screen-stack">
+              <div className="screen-toolbar">
+                <label className="search-box">
+                  <Search aria-hidden="true" />
+                  <input
+                    value={query}
+                    onChange={(event) => setQuery(event.target.value)}
+                    placeholder="Search candidates"
+                  />
+                </label>
+              </div>
+              <div className="filter-toolbar" aria-label="Candidate filters">
+                <TechnologyChipFilter
+                  label="Skills"
+                  options={technologyOptions}
+                  placeholder="Type Java, AWS, React..."
+                  selectedValues={parseFilterValues(skillFilter)}
+                  onChange={(values) =>
+                    setSkillFilter(serializeFilterValues(values))
+                  }
+                />
+                <label>
+                  Education
+                  <select
+                    value={educationFilter}
+                    onChange={(event) => setEducationFilter(event.target.value)}
+                  >
+                    <option value="">Any education</option>
+                    {educationOptions.map((education) => (
+                      <option key={education} value={education}>
+                        {education}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label>
+                  Location
+                  <input
+                    value={locationFilter}
+                    onChange={(event) => setLocationFilter(event.target.value)}
+                    placeholder="Seattle"
+                  />
+                </label>
+                <label>
+                  Min years
+                  <input
+                    min="0"
+                    type="number"
+                    value={minYearsFilter}
+                    onChange={(event) => setMinYearsFilter(event.target.value)}
+                    placeholder="3"
+                  />
+                </label>
+              </div>
+              <section className="data-grid">
+                {filteredCandidates.map((candidate) => (
+                  <article className="candidate-card" key={candidate.id}>
+                    <div className="panel-heading">
+                      <h2>{candidate.candidateName}</h2>
+                      <em className="status-chip">
+                        {candidate.topPositions[0]?.score ?? 0}%
+                      </em>
+                    </div>
+                    <p>
+                      {candidate.fileName}{" "}
+                      <CandidateResumeFileLinks candidate={candidate} />
+                    </p>
+                    <strong style={{ fontSize: "13px" }}>
+                      {candidate.topPositions[0]?.role.title ??
+                        "No recommendation"}
+                    </strong>
+                    <span className="candidate-meta">
+                      {candidate.structured.skills.slice(0, 4).join(", ") ||
+                        "No skills extracted"}
+                      {candidate.structured.location
+                        ? ` | ${candidate.structured.location}`
+                        : ""}
+                      {candidate.structured.yearsExperience !== null
+                        ? ` | ${candidate.structured.yearsExperience} yrs`
+                        : ""}
+                    </span>
+                    <small>{candidate.topPositions[0]?.explanation}</small>
+                    {userCanSubmitRecruiterOverride ? (
                       <button
                         type="button"
-                        className="queue-icon-button shrink-0"
-                        aria-label="Dismiss duplicate notices"
-                        title="Dismiss"
-                        onClick={() => setUploadDuplicateWarnings([])}
+                        className="icon-text-button mt-3 text-left self-start"
+                        onClick={() => setOverrideCandidate(candidate)}
                       >
-                        <X aria-hidden={true} />
+                        Flag recruiter override (audit-only)
                       </button>
-                    </div>
-                    <ul className="upload-duplicate-list mt-3 list-none space-y-1.5 p-0 font-medium">
-                      {uploadDuplicateWarnings.map((dup) => (
-                        <li key={`${dup.fileName}:${dup.duplicateKey}:${dup.clusterKey}:${dup.source}`}>
-                          <span className="text-ink">{dup.fileName}</span>
-                          <span className="text-muted"> — {dup.message}</span>
-                          {dup.matchedFileName ? (
-                            <span className="text-muted"> ({dup.matchedFileName})</span>
-                          ) : null}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                ) : null}
-                <button
-                  className="run-button"
-                  onClick={uploadResumes}
-                  disabled={isUploading || !files.length}
-                  title={
-                    !files.length
-                      ? "Add at least one résumé file (PDF, DOCX, TXT, or ZIP) to run analysis."
-                      : undefined
-                  }
-                >
-                  <SlidersHorizontal aria-hidden="true" />
-                  {isUploading ? "Processing resumes..." : "Run SkillMatch Analysis"}
-                </button>
-              </section>
-
-              <section className="concept-panel overview-panel">
-                <div className="panel-heading">
-                  <h2>Skill Match Overview</h2>
-                  {selectedCandidate ? (
-                    <span className="overview-panel-candidate-heading">
-                      <span>{selectedCandidate.candidateName}</span>
-                      <CandidateResumeFileLinks candidate={selectedCandidate} />
-                    </span>
-                  ) : null}
-                </div>
-                <div className="overview-content">
-                  <div className="overview-summary">
-                    <div className={`score-column${selectedResult ? "" : " is-empty"}`}>
-                      <div
-                        className="score-ring large"
-                        style={{ "--score": `${selectedResult?.score ?? 0}%` } as CSSProperties}
-                        aria-label={selectedResult ? `Match score ${selectedResult.score}%` : "No match score yet"}
-                      >
-                        <strong>{selectedResult ? `${selectedResult.score}%` : "—"}</strong>
-                      </div>
-                      <strong>Overall Match</strong>
-                      <span>{selectedResult ? selectedRole.title : "Upload resumes to rank positions"}</span>
-                    </div>
-                    <SkillList title="Top Matched Skills" items={matchedSkills.slice(0, 8)} />
-                    <ReadinessSignals result={selectedResult} />
-                    <GapList gaps={missingSkills.slice(0, 8)} />
-                  </div>
-                  <RoleSkillGapChart
-                    candidateName={selectedCandidate?.candidateName}
-                    items={skillGapChartItems}
-                    roleTitle={selectedRole.title}
-                  />
-                </div>
-              </section>
-
-              <aside className="right-stack">
-                <SavedTargetRolesPanel
-                  currentRoleSaved={Boolean(savedCurrentRole)}
-                  roles={savedRoles}
-                  bookmarkDisabled={!selectedResult}
-                  bookmarkDisabledReason="Run analysis on at least one résumé to snapshot match scores for this role."
-                  onRemove={removeSavedRole}
-                  onSave={saveCurrentTargetRole}
-                  onSelect={(id) => {
-                    setRoleId(id);
-                    setView("learning");
-                  }}
-                />
-                <RecommendationPanel candidate={selectedCandidate} />
-                <AiInsightPanel insight={selectedCandidate?.aiInsight ?? null} />
-                <RecentCandidates candidates={candidates} onSelect={setSelectedCandidateId} />
-              </aside>
-            </section>
-          </>
-        ) : null}
-
-        {view === "analyses" ? (
-          <section className="screen-stack">
-            <div className="screen-toolbar">
-              <label className="search-box">
-                <Search aria-hidden="true" />
-                <input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Search candidates" />
-              </label>
-              <button className="icon-text-button" onClick={() => void refreshRecords()}>Refresh</button>
-            </div>
-            <div className="filter-toolbar" aria-label="Candidate filters">
-              <label>
-                Skills
-                <input value={skillFilter} onChange={(event) => setSkillFilter(event.target.value)} placeholder="java, aws" />
-              </label>
-              <label>
-                Education
-                <input value={educationFilter} onChange={(event) => setEducationFilter(event.target.value)} placeholder="Bachelor" />
-              </label>
-              <label>
-                Location
-                <input value={locationFilter} onChange={(event) => setLocationFilter(event.target.value)} placeholder="Seattle" />
-              </label>
-              <label>
-                Min years
-                <input
-                  min="0"
-                  type="number"
-                  value={minYearsFilter}
-                  onChange={(event) => setMinYearsFilter(event.target.value)}
-                  placeholder="3"
-                />
-              </label>
-            </div>
-            <section className="data-grid">
-              {filteredCandidates.map((candidate) => (
-                <article className="candidate-card" key={candidate.id}>
-                  <div className="panel-heading">
-                    <h2>{candidate.candidateName}</h2>
-                    <em className="status-chip">{candidate.topPositions[0]?.score ?? 0}%</em>
-                  </div>
-                  <p>
-                    {candidate.fileName}{" "}
-                    <CandidateResumeFileLinks candidate={candidate} />
-                  </p>
-                  <strong style={{ fontSize: "13px" }}>{candidate.topPositions[0]?.role.title ?? "No recommendation"}</strong>
-                  <span className="candidate-meta">
-                    {(candidate.structured.skills.slice(0, 4).join(", ") || "No skills extracted")}
-                    {candidate.structured.location ? ` | ${candidate.structured.location}` : ""}
-                    {candidate.structured.yearsExperience !== null ? ` | ${candidate.structured.yearsExperience} yrs` : ""}
-                  </span>
-                  <small>{candidate.topPositions[0]?.explanation}</small>
-                  {userCanSubmitRecruiterOverride ? (
-                    <button
-                      type="button"
-                      className="icon-text-button mt-3 text-left self-start"
-                      onClick={() => setOverrideCandidate(candidate)}
-                    >
-                      Flag recruiter override (audit-only)
-                    </button>
-                  ) : null}
-                </article>
-              ))}
-              {!filteredCandidates.length ? (
-                candidates.length > 0 ? (
-                  <EmptyPanel
-                    title="No matching candidates"
-                    text="None of the candidates currently loaded match. Clear the search box or loosen Skill / Location / Education / Min years, then Refresh."
-                  />
-                ) : hasActiveServerCandidateFilters ? (
-                  <EmptyPanel
-                    title="No candidates match these filters"
-                    text="The server returned no rows for your Skill / Location / Education / Min years filters. Clear or loosen them and press Refresh—you may have excluded an upload you just processed."
-                  />
-                ) : (
-                  <EmptyPanel
-                    title="No candidate analyses yet"
-                    text="No candidates yet—upload from the Dashboard tab. Analyses are available after you process résumés."
-                  />
-                )
-              ) : null}
-            </section>
-            <HistoryTable analyses={analyses} status={analysisHistoryStatus} />
-          </section>
-        ) : null}
-
-        {view === "learning" ? (
-          <section className="screen-stack">
-            <div className="screen-toolbar">
-              <label className="role-context learning-resume-picker">
-                Resume
-                <select
-                  value={selectedLearningCandidate?.id ?? ""}
-                  onChange={(event) => setSelectedLearningCandidateId(event.target.value)}
-                  disabled={!candidates.length}
-                >
-                  {candidates.length ? (
-                    candidates.map((candidate) => (
-                      <option key={candidate.id} value={candidate.id}>
-                        {candidate.candidateName} - {candidate.fileName}
-                      </option>
-                    ))
-                  ) : (
-                    <option value="">Upload a resume first</option>
-                  )}
-                </select>
-              </label>
-              <button className="icon-text-button" type="button" onClick={() => void refreshRecords()}>
-                Refresh
-              </button>
-            </div>
-            <section className="metric-grid">
-              <Metric label="Saved target roles" value={savedRoles.length} />
-              <Metric label="Current role progress" value={savedCurrentRole ? `${savedCurrentRole.progressPercent}%` : "Not saved"} />
-              <Metric
-                label="Assigned modules"
-                value={selectedLearningCandidate?.assignedLearningModules?.length ?? 0}
-              />
-            </section>
-            <LearningAssignmentPanel
-              busy={learningAssignmentStatus === "saving"}
-              candidate={selectedLearningCandidate}
-              onToggle={(moduleId, assigned) => void assignLearningModule(moduleId, assigned)}
-              role={selectedRole}
-            />
-            <SavedRoleProgress roles={savedRoles} onRemove={removeSavedRole} onSelect={setRoleId} />
-          </section>
-        ) : null}
-
-        {view === "workforce" ? (
-          <section className="screen-stack">
-            <div className="screen-toolbar">
-              <span className="text-[13px] text-muted">Counts reflect analyzed candidates from this workspace.</span>
-              <button className="icon-text-button" type="button" onClick={() => void refreshRecords()}>
-                Refresh
-              </button>
-            </div>
-            <section className="metric-grid">
-              <Metric label="Open role families" value={roles.length} />
-              <Metric label="Candidates reviewed" value={candidates.length} />
-              <Metric label="Tracked skill gaps" value={workforceGaps.length || selectedRole.requiredSkills.length} />
-            </section>
-            <section className="concept-panel">
-              <div className="panel-heading">
-                <h2>Role Coverage Matrix</h2>
-                <span>Seed catalog (demo)</span>
-              </div>
-              <p className="m-0 mb-3 text-[12px] leading-snug text-muted">
-                Roles and skills come from bundled seed data—not live headcount or ATS openings.
-              </p>
-              <div className="role-matrix">
-                {roles.map((role) => (
-                  <article key={role.id}>
-                    <strong>{role.title}</strong>
-                    <span>{role.department}</span>
-                    <small>{role.requiredSkills.slice(0, 5).join(", ")}</small>
+                    ) : null}
                   </article>
                 ))}
-              </div>
-            </section>
-            <section className="flex flex-col gap-4 rounded-lg border border-border bg-panel p-4 shadow-md md:p-[clamp(1rem,1.15vw,1.125rem)]">
-              <div className="flex flex-wrap items-end justify-between gap-x-3 gap-y-2 border-b border-border pb-3">
-                <h2 className="m-0 text-[15px] font-bold tracking-tight text-[#0f172a]">Common skill gaps</h2>
-                <span className="max-w-xs text-end text-xs font-semibold leading-snug text-muted sm:max-w-sm">
-                  {selectedRole.title}
-                </span>
-              </div>
-              <p className="m-0 text-[13px] leading-relaxed text-muted">
-                Aggregated missing skills from recent analyses (when available).
-                {!workforceGaps.length && !candidates.length ? (
-                  <span className="block pt-2 font-medium text-ink">
-                    Illustrative gaps from the selected role&apos;s requirements appear below until résumé analyses exist.
-                  </span>
-                ) : null}
-              </p>
-              <div className="flex flex-col gap-3">
-                {(workforceGaps.length
-                  ? workforceGaps
-                  : selectedRole.requiredSkills
-                      .slice(0, 5)
-                      .map((skill, index) => [skill, 5 - index] as [string, number])
-                ).map(([skill, count]) => (
-                  <div
-                    key={skill}
-                    className="grid grid-cols-1 items-center gap-x-4 gap-y-2 min-[460px]:grid-cols-[minmax(7rem,8.5rem)_minmax(0,1fr)_2.75rem]"
-                  >
-                    <span className="truncate text-[13px] font-medium capitalize text-ink min-[460px]:row-auto">
-                      {skill}
-                    </span>
-                    <meter
-                      className="col-span-full min-h-[6px] w-full min-w-0 appearance-none min-[460px]:col-auto"
-                      value={Number(count)}
-                      min={0}
-                      max={workforceGapMeterMax}
+                {!filteredCandidates.length ? (
+                  candidates.length > 0 ? (
+                    <EmptyPanel
+                      title="No matching candidates"
+                      text="None of the candidates currently loaded match. Clear the search box or loosen Skill / Location / Education / Min years, then Refresh."
                     />
-                    <strong className="text-left text-[13px] font-bold tabular-nums text-muted min-[460px]:text-end">
-                      {Number(count)}
-                    </strong>
-                  </div>
-                ))}
-              </div>
-              <div
-                role="status"
-                aria-live="polite"
-                aria-busy={isUploading && files.length > 0}
-                className="mt-0.5 flex items-start gap-3 border-t border-border pt-3"
-              >
-                <span
-                  className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-panel text-subtle ring-1 ring-border"
-                  aria-hidden={true}
-                >
-                  <Activity className="size-[17px]" strokeWidth={2} />
-                </span>
-                <div className="flex min-w-0 flex-1 flex-col gap-1">
-                  <span className="text-[12px] font-bold uppercase tracking-wide text-subtle">Browser upload staging</span>
-                  <p className="m-0 text-[13px] font-medium leading-snug text-ink">
-                    {isUploading && files.length > 0 ? (
-                      <>
-                        <span className="font-semibold text-brand">{files.length}</span> file
-                        {files.length === 1 ? "" : "s"} queued in this browser before analysis runs—not a server job queue.
-                      </>
-                    ) : (
-                      <span className="text-muted">Nothing staged in your browser queue.</span>
-                    )}
+                  ) : hasActiveServerCandidateFilters ? (
+                    <EmptyPanel
+                      title="No candidates match these filters"
+                      text="The server returned no rows for your Skill / Location / Education / Min years filters. Clear or loosen them and press Refresh—you may have excluded an upload you just processed."
+                    />
+                  ) : (
+                    <EmptyPanel
+                      title="No candidate analyses yet"
+                      text="No candidates yet—upload from the Dashboard tab. Analyses are available after you process résumés."
+                    />
+                  )
+                ) : null}
+              </section>
+              <HistoryTable
+                analyses={analyses}
+                status={analysisHistoryStatus}
+              />
+            </section>
+          ) : null}
+
+          {view === "learning" ? (
+            <section className="screen-stack learning-screen">
+              <div className="screen-toolbar learning-toolbar">
+                <div>
+                  <h2>Learning plans</h2>
+                  <p>
+                    Review every uploaded resume, confirm the best-fit training
+                    target, and assign modules to that employee.
                   </p>
                 </div>
               </div>
+              <section className="learning-layout">
+                <LearningResumeRoster
+                  candidates={candidates}
+                  selectedCandidateId={selectedLearningCandidate?.id ?? ""}
+                  onSelect={setSelectedLearningCandidateId}
+                />
+                <LearningAssignmentPanel
+                  busy={learningAssignmentStatus === "saving"}
+                  candidate={selectedLearningCandidate}
+                  onRoleChange={(nextRoleId) => {
+                    if (!selectedLearningCandidate) {
+                      return;
+                    }
+                    setLearningRoleOverrides((current) => ({
+                      ...current,
+                      [selectedLearningCandidate.id]: nextRoleId,
+                    }));
+                  }}
+                  onToggle={(moduleId, assigned) =>
+                    void assignLearningModule(moduleId, assigned)
+                  }
+                  role={selectedLearningRole}
+                  selectedMatch={selectedLearningMatch}
+                />
+              </section>
             </section>
-          </section>
-        ) : null}
+          ) : null}
 
-        {view === "audit" ? (
-          <section className="screen-stack">
-            <section className="concept-panel audit-log-panel">
-              <div className="panel-heading">
-                <h2>Audit Log</h2>
-                <span>{user.role === "system_admin" ? `${auditEvents.length} events` : "Admin only"}</span>
+          {view === "workforce" ? (
+            <section className="screen-stack">
+              <div className="screen-toolbar">
+                <span className="text-[13px] text-muted">
+                  Counts reflect analyzed candidates from this workspace.
+                </span>
               </div>
-              {user.role === "system_admin" ? (
-                <>
-                  <div className="mb-3 flex flex-wrap justify-end gap-2">
-                    <button className="icon-text-button" type="button" onClick={() => void refreshRecords()}>
-                      Refresh log
+              <section className="metric-grid">
+                <Metric label="Open role families" value={roles.length} />
+                <Metric label="Candidates reviewed" value={candidates.length} />
+                <Metric
+                  label="Tracked skill gaps"
+                  value={
+                    workforceGaps.length || selectedRole.requiredSkills.length
+                  }
+                />
+              </section>
+              <section className="concept-panel">
+                <div className="panel-heading">
+                  <h2>Role Coverage Matrix</h2>
+                  <span>Seed catalog (demo)</span>
+                </div>
+                <p className="m-0 mb-3 text-[12px] leading-snug text-muted">
+                  Roles and skills come from bundled seed data—not live
+                  headcount or ATS openings.
+                </p>
+                <div className="role-matrix">
+                  {roles.map((role) => (
+                    <article key={role.id}>
+                      <strong>{role.title}</strong>
+                      <span>{role.department}</span>
+                      <small>
+                        {role.requiredSkills.slice(0, 5).join(", ")}
+                      </small>
+                    </article>
+                  ))}
+                </div>
+              </section>
+              <section className="flex flex-col gap-4 rounded-lg border border-border bg-panel p-4 shadow-md md:p-[clamp(1rem,1.15vw,1.125rem)]">
+                <div className="flex flex-wrap items-end justify-between gap-x-3 gap-y-2 border-b border-border pb-3">
+                  <h2 className="m-0 text-[15px] font-bold tracking-tight text-[#0f172a]">
+                    Common skill gaps
+                  </h2>
+                  <span className="max-w-xs text-end text-xs font-semibold leading-snug text-muted sm:max-w-sm">
+                    {selectedRole.title}
+                  </span>
+                </div>
+                <p className="m-0 text-[13px] leading-relaxed text-muted">
+                  Aggregated missing skills from recent analyses (when
+                  available).
+                  {!workforceGaps.length && !candidates.length ? (
+                    <span className="block pt-2 font-medium text-ink">
+                      Illustrative gaps from the selected role&apos;s
+                      requirements appear below until résumé analyses exist.
+                    </span>
+                  ) : null}
+                </p>
+                <div className="flex flex-col gap-3">
+                  {(workforceGaps.length
+                    ? workforceGaps
+                    : selectedRole.requiredSkills
+                        .slice(0, 5)
+                        .map(
+                          (skill, index) =>
+                            [skill, 5 - index] as [string, number],
+                        )
+                  ).map(([skill, count]) => (
+                    <div
+                      key={skill}
+                      className="grid grid-cols-1 items-center gap-x-4 gap-y-2 min-[460px]:grid-cols-[minmax(7rem,8.5rem)_minmax(0,1fr)_2.75rem]"
+                    >
+                      <span className="truncate text-[13px] font-medium capitalize text-ink min-[460px]:row-auto">
+                        {skill}
+                      </span>
+                      <meter
+                        className="col-span-full min-h-[6px] w-full min-w-0 appearance-none min-[460px]:col-auto"
+                        value={Number(count)}
+                        min={0}
+                        max={workforceGapMeterMax}
+                      />
+                      <strong className="text-left text-[13px] font-bold tabular-nums text-muted min-[460px]:text-end">
+                        {Number(count)}
+                      </strong>
+                    </div>
+                  ))}
+                </div>
+                <div
+                  role="status"
+                  aria-live="polite"
+                  aria-busy={isUploading && files.length > 0}
+                  className="mt-0.5 flex items-start gap-3 border-t border-border pt-3"
+                >
+                  <span
+                    className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-panel text-subtle ring-1 ring-border"
+                    aria-hidden={true}
+                  >
+                    <Activity className="size-[17px]" strokeWidth={2} />
+                  </span>
+                  <div className="flex min-w-0 flex-1 flex-col gap-1">
+                    <span className="text-[12px] font-bold uppercase tracking-wide text-subtle">
+                      Browser upload staging
+                    </span>
+                    <p className="m-0 text-[13px] font-medium leading-snug text-ink">
+                      {isUploading && files.length > 0 ? (
+                        <>
+                          <span className="font-semibold text-brand">
+                            {files.length}
+                          </span>{" "}
+                          file
+                          {files.length === 1 ? "" : "s"} queued in this browser
+                          before analysis runs—not a server job queue.
+                        </>
+                      ) : (
+                        <span className="text-muted">
+                          Nothing staged in your browser queue.
+                        </span>
+                      )}
+                    </p>
+                  </div>
+                </div>
+              </section>
+            </section>
+          ) : null}
+
+          {view === "audit" ? (
+            <section className="screen-stack">
+              <section className="concept-panel audit-log-panel">
+                <div className="panel-heading">
+                  <h2>Audit Log</h2>
+                  <span>
+                    {user.role === "system_admin"
+                      ? `${auditEvents.length} events`
+                      : "Admin only"}
+                  </span>
+                </div>
+                {user.role === "system_admin" ? (
+                  <AuditTable events={auditEvents} />
+                ) : (
+                  <EmptyPanel
+                    title="Restricted screen"
+                    text="System administrators can view login, upload, and override events."
+                  />
+                )}
+              </section>
+            </section>
+          ) : null}
+
+          {view === "settings" ? (
+            <section className="screen-stack">
+              <form
+                className="concept-panel settings-grid"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  setNotice("Settings saved for this session.");
+                }}
+              >
+                <section className="settings-section">
+                  <div className="panel-heading">
+                    <h2>Profile</h2>
+                    <span>{user.role.replace("_", " ")}</span>
+                  </div>
+                  <label>
+                    Full name
+                    <input
+                      value={settingsProfile.displayName}
+                      onChange={(event) =>
+                        setSettingsProfile((current) => ({
+                          ...current,
+                          displayName: event.target.value,
+                        }))
+                      }
+                    />
+                  </label>
+                  <label>
+                    Work email
+                    <input
+                      type="email"
+                      value={settingsProfile.email}
+                      onChange={(event) =>
+                        setSettingsProfile((current) => ({
+                          ...current,
+                          email: event.target.value,
+                        }))
+                      }
+                    />
+                  </label>
+                  <label>
+                    Team
+                    <input
+                      value={settingsProfile.team}
+                      onChange={(event) =>
+                        setSettingsProfile((current) => ({
+                          ...current,
+                          team: event.target.value,
+                        }))
+                      }
+                    />
+                  </label>
+                </section>
+
+                <section className="settings-section">
+                  <div className="panel-heading">
+                    <h2>Analysis Defaults</h2>
+                    <span>Workspace</span>
+                  </div>
+                  <label>
+                    Hiring region
+                    <select
+                      value={settingsProfile.region}
+                      onChange={(event) =>
+                        setSettingsProfile((current) => ({
+                          ...current,
+                          region: event.target.value,
+                        }))
+                      }
+                    >
+                      <option>North America</option>
+                      <option>EMEA</option>
+                      <option>APAC</option>
+                      <option>LATAM</option>
+                    </select>
+                  </label>
+                  <label>
+                    Default comparison role
+                    <select
+                      value={settingsProfile.defaultRoleId}
+                      onChange={(event) => {
+                        setRoleId(event.target.value);
+                        setSettingsProfile((current) => ({
+                          ...current,
+                          defaultRoleId: event.target.value,
+                        }));
+                      }}
+                    >
+                      {roles.map((role) => (
+                        <option key={role.id} value={role.id}>
+                          {role.title}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label>
+                    Review threshold
+                    <select
+                      value={settingsProfile.reviewThreshold}
+                      onChange={(event) =>
+                        setSettingsProfile((current) => ({
+                          ...current,
+                          reviewThreshold: event.target.value,
+                        }))
+                      }
+                    >
+                      <option value="60">60% match</option>
+                      <option value="70">70% match</option>
+                      <option value="80">80% match</option>
+                      <option value="90">90% match</option>
+                    </select>
+                  </label>
+                </section>
+
+                <section className="settings-section settings-wide-section">
+                  <div className="panel-heading">
+                    <h2>Notifications & Access</h2>
+                    <span>Session only</span>
+                  </div>
+                  <label className="settings-toggle">
+                    <input
+                      type="checkbox"
+                      checked={settingsProfile.weeklyDigest}
+                      onChange={(event) =>
+                        setSettingsProfile((current) => ({
+                          ...current,
+                          weeklyDigest: event.target.checked,
+                        }))
+                      }
+                    />
+                    <span>
+                      <strong>Weekly learning digest</strong>
+                      <small>
+                        Send a concise summary of assigned modules, unresolved
+                        gaps, and newly uploaded resumes.
+                      </small>
+                    </span>
+                  </label>
+                  <label className="settings-toggle">
+                    <input
+                      type="checkbox"
+                      checked={settingsProfile.auditCopy}
+                      onChange={(event) =>
+                        setSettingsProfile((current) => ({
+                          ...current,
+                          auditCopy: event.target.checked,
+                        }))
+                      }
+                    />
+                    <span>
+                      <strong>Copy me on override activity</strong>
+                      <small>
+                        Notify this account when recruiter overrides or learning
+                        assignments are recorded.
+                      </small>
+                    </span>
+                  </label>
+                  <div className="settings-actions">
+                    <p>
+                      Changes here personalize this browser session and do not
+                      modify server account records.
+                    </p>
+                    <button className="primary-action" type="submit">
+                      Save settings
                     </button>
                   </div>
-                  <AuditTable events={auditEvents} />
-                </>
-              ) : (
-                <EmptyPanel
-                  title="Restricted screen"
-                  text="System administrators can view login, upload, and override events."
-                />
-              )}
+                </section>
+              </form>
             </section>
-          </section>
-        ) : null}
-
-        {view === "settings" ? (
-          <section className="screen-stack">
-            <section className="concept-panel settings-grid">
-              <div>
-                <h2>Account</h2>
-                <p>{user.name}</p>
-                <strong>{user.email}</strong>
-                <span>{user.role.replace("_", " ")}</span>
-              </div>
-              <div>
-                <h2>MVP Controls</h2>
-                <p>Demo accounts for this build are defined in server configuration.</p>
-                <p>Session lifetime is eight hours.</p>
-                <p className="m-0 text-[13px] leading-relaxed text-muted">
-                  Persistence follows the workspace status above — memory mode keeps analyses only until the server restarts;
-                  Postgres with migrations lets uploads and audit rows survive restarts.
-                </p>
-              </div>
-            </section>
-          </section>
-        ) : null}
+          ) : null}
         </section>
       </div>
 
@@ -1117,8 +1502,12 @@ function RecruiterOverrideModalInner({
   refreshRecords: () => void | Promise<void>;
   onRecordedNotice: (note: string) => void;
 }) {
-  const [promotedRoleId, setPromotedRoleId] = useState(() => candidate.topPositions[0]?.role.id ?? roles[0].id);
-  const [reason, setReason] = useState("Cross-team priority after panel review.");
+  const [promotedRoleId, setPromotedRoleId] = useState(
+    () => candidate.topPositions[0]?.role.id ?? roles[0].id,
+  );
+  const [reason, setReason] = useState(
+    "Cross-team priority after panel review.",
+  );
   const [busy, setBusy] = useState(false);
   const [errorMsg, setErrorMsg] = useState("");
 
@@ -1137,7 +1526,9 @@ function RecruiterOverrideModalInner({
           reason,
         }),
       });
-      const payload = (await response.json().catch(() => ({}))) as { error?: string };
+      const payload = (await response.json().catch(() => ({}))) as {
+        error?: string;
+      };
       if (!response.ok) {
         setErrorMsg(payload.error ?? "Override request failed.");
         return;
@@ -1167,16 +1558,22 @@ function RecruiterOverrideModalInner({
         onClick={(e) => e.stopPropagation()}
         onSubmit={submit}
       >
-        <h2 id="override-dialog-title" className="m-0 text-base font-bold text-ink">
+        <h2
+          id="override-dialog-title"
+          className="m-0 text-base font-bold text-ink"
+        >
           Flag recruiter override
         </h2>
         <p className="mt-2 text-[13px] leading-relaxed text-muted">
-          This records a decision in the audit log for stakeholders. It does <strong>not</strong> rewrite stored
-          SkillMatch scores yet.
+          This records a decision in the audit log for stakeholders. It does{" "}
+          <strong>not</strong> rewrite stored SkillMatch scores yet.
         </p>
         <p className="mt-1 text-[12px] text-subtle">
-          Candidate: <span className="font-semibold text-ink">{candidate.candidateName}</span> · file{" "}
-          {candidate.fileName}
+          Candidate:{" "}
+          <span className="font-semibold text-ink">
+            {candidate.candidateName}
+          </span>{" "}
+          · file {candidate.fileName}
         </p>
         <label className="role-context mt-4">
           Promoted role emphasis
@@ -1209,10 +1606,19 @@ function RecruiterOverrideModalInner({
           </p>
         ) : null}
         <div className="mt-4 flex flex-wrap justify-end gap-2">
-          <button type="button" className="icon-text-button" disabled={busy} onClick={onClose}>
+          <button
+            type="button"
+            className="icon-text-button"
+            disabled={busy}
+            onClick={onClose}
+          >
             Cancel
           </button>
-          <button type="submit" className="run-button mt-0 max-w-none min-h-[38px]" disabled={busy}>
+          <button
+            type="submit"
+            className="run-button mt-0 max-w-none min-h-[38px]"
+            disabled={busy}
+          >
             {busy ? "Recording…" : "Record audit entry"}
           </button>
         </div>
@@ -1238,13 +1644,19 @@ function SkillList({ title, items }: { title: string; items: string[] }) {
           ))}
         </ul>
       ) : (
-        <p className="list-placeholder">Upload a resume to see matched skills.</p>
+        <p className="list-placeholder">
+          Upload a resume to see matched skills.
+        </p>
       )}
     </div>
   );
 }
 
-function GapList({ gaps }: { gaps: CandidateAnalysis["topPositions"][number]["missingSkills"] }) {
+function GapList({
+  gaps,
+}: {
+  gaps: CandidateAnalysis["topPositions"][number]["missingSkills"];
+}) {
   return (
     <div>
       <h3>
@@ -1267,7 +1679,11 @@ function GapList({ gaps }: { gaps: CandidateAnalysis["topPositions"][number]["mi
   );
 }
 
-function ReadinessSignals({ result }: { result?: CandidateAnalysis["topPositions"][number] }) {
+function ReadinessSignals({
+  result,
+}: {
+  result?: CandidateAnalysis["topPositions"][number];
+}) {
   if (!result) {
     return (
       <div>
@@ -1275,7 +1691,10 @@ function ReadinessSignals({ result }: { result?: CandidateAnalysis["topPositions
           <BookmarkCheck aria-hidden="true" />
           Readiness Signals
         </h3>
-        <p className="list-placeholder">Upload a resume to compare experience, certifications, and soft skills.</p>
+        <p className="list-placeholder">
+          Upload a resume to compare experience, certifications, and soft
+          skills.
+        </p>
       </div>
     );
   }
@@ -1284,7 +1703,7 @@ function ReadinessSignals({ result }: { result?: CandidateAnalysis["topPositions
   const experience = details?.experience ?? {
     candidateYears: result.structured.yearsExperience,
     minimumYears: result.role.minimumYearsExperience,
-    idealYears: result.role.idealYearsExperience
+    idealYears: result.role.idealYearsExperience,
   };
   const certifications = details?.certifications ?? { matched: 0, total: 0 };
   const softSkills = details?.softSkills ?? { matched: 0, total: 0 };
@@ -1299,26 +1718,129 @@ function ReadinessSignals({ result }: { result?: CandidateAnalysis["topPositions
         <li>
           <span>Experience</span>
           <small>
-            {experience.candidateYears ?? "Unknown"} yrs vs {experience.minimumYears}-{experience.idealYears}+ target
+            {experience.candidateYears ?? "Unknown"} yrs vs{" "}
+            {experience.minimumYears}-{experience.idealYears}+ target
           </small>
         </li>
         <li>
           <span>Certifications</span>
-          <small>{certifications.matched}/{certifications.total} matched</small>
+          <small>
+            {certifications.matched}/{certifications.total} matched
+          </small>
         </li>
         <li>
           <span>Soft skills</span>
-          <small>{softSkills.matched}/{softSkills.total} matched</small>
+          <small>
+            {softSkills.matched}/{softSkills.total} matched
+          </small>
         </li>
       </ul>
     </div>
   );
 }
 
+function DashboardStatsPanel({
+  stats,
+}: {
+  stats: {
+    resumeCount: number;
+    averageMatch: number;
+    assignedModules: number;
+    activeRoleFamilies: number;
+    roleDistribution: Array<[string, number]>;
+  };
+}) {
+  const maxRoleCount = Math.max(
+    ...stats.roleDistribution.map(([, count]) => count),
+    1,
+  );
+
+  return (
+    <section
+      className="dashboard-stats-panel"
+      aria-label="Dashboard statistics"
+    >
+      <div className="dashboard-stat-card">
+        <span>Resumes analyzed</span>
+        <strong>{stats.resumeCount}</strong>
+      </div>
+      <div className="dashboard-stat-card">
+        <span>Average top match</span>
+        <strong>{stats.resumeCount ? `${stats.averageMatch}%` : "—"}</strong>
+      </div>
+      <div className="dashboard-stat-card">
+        <span>Assigned modules</span>
+        <strong>{stats.assignedModules}</strong>
+      </div>
+      <div className="dashboard-stat-card">
+        <span>Role families</span>
+        <strong>{stats.activeRoleFamilies}</strong>
+      </div>
+      <div className="role-distribution-card">
+        <span>Recommended role mix</span>
+        {stats.roleDistribution.length ? (
+          <ul>
+            {stats.roleDistribution.map(([roleTitle, count]) => (
+              <li key={roleTitle}>
+                <small>{roleTitle}</small>
+                <div aria-hidden="true">
+                  <i
+                    style={{
+                      width: `${Math.max(8, (count / maxRoleCount) * 100)}%`,
+                    }}
+                  />
+                </div>
+                <b>{count}</b>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p>No analyzed resumes yet.</p>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function DashboardGapPanel({ gaps }: { gaps: Array<[string, number]> }) {
+  const maxGapCount = Math.max(...gaps.map(([, count]) => count), 1);
+
+  return (
+    <section
+      className="dashboard-gap-panel"
+      aria-labelledby="dashboard-gap-title"
+    >
+      <div className="panel-heading">
+        <h3 id="dashboard-gap-title">Top Workforce Gaps</h3>
+        <span>{gaps.length ? "Across resumes" : "No gap data"}</span>
+      </div>
+      {gaps.length ? (
+        <ul className="dashboard-gap-list">
+          {gaps.slice(0, 5).map(([skill, count]) => (
+            <li key={skill}>
+              <span className="dashboard-gap-skill">{skill}</span>
+              <span className="dashboard-gap-meter" aria-hidden="true">
+                <span
+                  style={{
+                    width: `${Math.max(8, (count / maxGapCount) * 100)}%`,
+                  }}
+                />
+              </span>
+              <strong>{count}</strong>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="chart-caption">No analyzed resumes yet.</p>
+      )}
+    </section>
+  );
+}
+
 function RoleSkillGapChart({
   candidateName,
   items,
-  roleTitle
+  roleTitle,
 }: {
   candidateName?: string;
   items: SkillGapChartItem[];
@@ -1340,7 +1862,8 @@ function RoleSkillGapChart({
           <h3 id="skill-gap-chart-title">Role Skill-Gap Chart</h3>
         </div>
         <p className="chart-caption">
-          Upload a resume and run analysis to see skill coverage for {roleTitle}.
+          Upload a resume and run analysis to see skill coverage for {roleTitle}
+          .
         </p>
         <div className="chart-placeholder" />
       </section>
@@ -1348,7 +1871,10 @@ function RoleSkillGapChart({
   }
 
   return (
-    <section className="skill-gap-chart-panel" aria-labelledby="skill-gap-chart-title">
+    <section
+      className="skill-gap-chart-panel"
+      aria-labelledby="skill-gap-chart-title"
+    >
       <div className="panel-heading">
         <h3 id="skill-gap-chart-title">Role Skill-Gap Chart</h3>
         <span>{candidateName ?? "Candidate"}</span>
@@ -1368,11 +1894,14 @@ function RoleSkillGapChart({
         >
           {items.map((item, index) => {
             const y = 18 + index * 42;
-            const fillWidth = Math.max(36, Math.round((item.coverage / 100) * barW));
+            const fillWidth = Math.max(
+              36,
+              Math.round((item.coverage / 100) * barW),
+            );
             const barClassName = [
               "chart-bar-fill",
               item.status === "matched" ? "is-matched" : "",
-              item.source === "required" ? "is-required" : "is-preferred"
+              item.source === "required" ? "is-required" : "is-preferred",
             ]
               .filter(Boolean)
               .join(" ");
@@ -1382,8 +1911,24 @@ function RoleSkillGapChart({
                 <text className="chart-skill-label" x="0" y="14">
                   {item.skill}
                 </text>
-                <rect className="chart-bar-track" height="14" rx="7" ry="7" width={barW} x={barX} y="0" />
-                <rect className={barClassName} height="14" rx="7" ry="7" width={fillWidth} x={barX} y="0" />
+                <rect
+                  className="chart-bar-track"
+                  height="14"
+                  rx="7"
+                  ry="7"
+                  width={barW}
+                  x={barX}
+                  y="0"
+                />
+                <rect
+                  className={barClassName}
+                  height="14"
+                  rx="7"
+                  ry="7"
+                  width={fillWidth}
+                  x={barX}
+                  y="0"
+                />
                 <text className="chart-meta-label" x={metaX} y="12">
                   {item.status === "matched" ? "Matched" : item.importance}
                 </text>
@@ -1410,115 +1955,188 @@ function RoleSkillGapChart({
   );
 }
 
-function SavedTargetRolesPanel({
-  currentRoleSaved,
-  roles,
-  bookmarkDisabled,
-  bookmarkDisabledReason,
-  onRemove,
-  onSave,
-  onSelect
+function TechnologyChipFilter({
+  label,
+  options,
+  placeholder,
+  selectedValues,
+  onChange,
 }: {
-  currentRoleSaved: boolean;
-  roles: SavedTargetRole[];
-  bookmarkDisabled?: boolean;
-  bookmarkDisabledReason?: string;
-  onRemove: (id: string) => void;
-  onSave: () => void;
-  onSelect: (roleId: string) => void;
+  label: string;
+  options: string[];
+  placeholder: string;
+  selectedValues: string[];
+  onChange: (values: string[]) => void;
 }) {
+  const [query, setQuery] = useState("");
+  const [focused, setFocused] = useState(false);
+  const selectedLookup = useMemo(
+    () => new Set(selectedValues.map((value) => value.toLowerCase())),
+    [selectedValues],
+  );
+  const normalizedQuery = query.trim().toLowerCase();
+  const suggestions = options
+    .filter((option) => !selectedLookup.has(option.toLowerCase()))
+    .filter((option) => {
+      if (!normalizedQuery) {
+        return true;
+      }
+      return (
+        option.toLowerCase().includes(normalizedQuery) ||
+        formatTechnologyLabel(option).toLowerCase().includes(normalizedQuery)
+      );
+    })
+    .slice(0, 7);
+
+  function addValue(nextValue: string) {
+    const trimmedValue = nextValue.trim();
+    if (!trimmedValue) {
+      return;
+    }
+    const matchedOption =
+      options.find(
+        (option) => option.toLowerCase() === trimmedValue.toLowerCase(),
+      ) ??
+      options.find(
+        (option) =>
+          formatTechnologyLabel(option).toLowerCase() ===
+          trimmedValue.toLowerCase(),
+      );
+    const committedValue = matchedOption ?? trimmedValue.toLowerCase();
+    if (selectedLookup.has(committedValue.toLowerCase())) {
+      setQuery("");
+      return;
+    }
+    onChange([...selectedValues, committedValue]);
+    setQuery("");
+  }
+
+  function removeValue(value: string) {
+    onChange(
+      selectedValues.filter(
+        (item) => item.toLowerCase() !== value.toLowerCase(),
+      ),
+    );
+  }
+
+  function handleKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Enter" || event.key === ",") {
+      event.preventDefault();
+      addValue(suggestions[0] ?? query);
+      return;
+    }
+    if (event.key === "Backspace" && !query && selectedValues.length) {
+      removeValue(selectedValues[selectedValues.length - 1]!);
+    }
+  }
+
   return (
-    <section className="concept-panel saved-target-panel" aria-labelledby="saved-target-roles-heading">
-      <div className="panel-heading">
-        <h2 id="saved-target-roles-heading">Saved Target Roles</h2>
-        <span>{roles.length}</span>
-      </div>
-      <p id="saved-target-roles-help" className="m-0 mb-3 text-[12px] leading-snug text-muted">
-        Candidates are persisted when you run analysis (see <strong className="font-semibold text-ink">Analyses</strong>).
-        Bookmark the <strong className="font-semibold text-ink">job role</strong> in the header to pin gap tracking and demo
-        learning picks—optional, separate from storing résumés.
-      </p>
-      <button
-        className="primary-action"
-        type="button"
-        onClick={onSave}
-        aria-describedby="saved-target-roles-help"
-        disabled={Boolean(bookmarkDisabled)}
-        title={bookmarkDisabled ? bookmarkDisabledReason : undefined}
-      >
-        <BookmarkCheck aria-hidden="true" />
-        {currentRoleSaved ? "Refresh bookmark & snapshot" : "Bookmark role for Learning"}
-      </button>
-      {roles.length ? (
-        <ul className="saved-role-list">
-          {roles.slice(0, 3).map((role) => (
-            <li key={role.id}>
-              <button type="button" onClick={() => onSelect(role.roleId)}>
-                <Target aria-hidden="true" />
-                <span>
-                  <strong>{role.roleTitle}</strong>
-                  <small>{role.currentScore === null ? "No score yet" : `${role.currentScore}% current match`}</small>
-                </span>
-                <em>{role.progressPercent}%</em>
-              </button>
+    <label className="chip-filter-label">
+      {label}
+      <div className="chip-filter-control">
+        <div className="chip-filter-input-row">
+          {selectedValues.map((value) => (
+            <span className="filter-chip" key={value}>
+              {formatTechnologyLabel(value)}
               <button
-                aria-label={`Remove ${role.roleTitle}`}
-                className="queue-icon-button"
-                onClick={() => onRemove(role.id)}
-                title={`Remove ${role.roleTitle}`}
                 type="button"
+                onClick={() => removeValue(value)}
+                aria-label={`Remove ${formatTechnologyLabel(value)}`}
               >
                 <X aria-hidden="true" />
               </button>
-            </li>
+            </span>
           ))}
-        </ul>
-      ) : (
-        <p className="list-placeholder">Bookmark a role above to unlock Learning progress—not required to keep analyzed candidates.</p>
-      )}
-    </section>
+          <input
+            aria-label={`${label} filter`}
+            value={query}
+            onBlur={() => setFocused(false)}
+            onChange={(event) => setQuery(event.target.value)}
+            onFocus={() => setFocused(true)}
+            onKeyDown={handleKeyDown}
+            placeholder={selectedValues.length ? "Add another" : placeholder}
+          />
+        </div>
+        {focused && normalizedQuery && suggestions.length ? (
+          <div
+            className="chip-filter-menu"
+            role="listbox"
+            aria-label={`${label} suggestions`}
+          >
+            {suggestions.map((option) => (
+              <button
+                key={option}
+                type="button"
+                role="option"
+                aria-selected="false"
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => addValue(option)}
+              >
+                <span>{formatTechnologyLabel(option)}</span>
+                <small>{option}</small>
+              </button>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </label>
   );
 }
 
-function SavedRoleProgress({
-  roles,
-  onRemove,
-  onSelect
+function LearningResumeRoster({
+  candidates,
+  selectedCandidateId,
+  onSelect,
 }: {
-  roles: SavedTargetRole[];
-  onRemove: (id: string) => void;
-  onSelect: (roleId: string) => void;
+  candidates: CandidateAnalysis[];
+  selectedCandidateId: string;
+  onSelect: (id: string) => void;
 }) {
   return (
-    <section className="concept-panel">
+    <section
+      className="concept-panel learning-roster-panel"
+      aria-labelledby="learning-roster-heading"
+    >
       <div className="panel-heading">
-        <h2>Target Role Progress</h2>
-        <span>{roles.length ? "Employee plan" : "No saved targets"}</span>
+        <h2 id="learning-roster-heading">Uploaded Resumes</h2>
+        <span>{candidates.length}</span>
       </div>
-      {roles.length ? (
-        <div className="saved-progress-grid">
-          {roles.map((role) => (
-            <article key={role.id}>
-              <div>
-                <strong>{role.roleTitle}</strong>
-                <span>{role.missingSkills.length ? `${role.missingSkills.slice(0, 3).join(", ")} gaps` : "No tracked gaps"}</span>
-              </div>
-              <meter min={0} max={100} value={role.progressPercent} />
-              <em>{role.progressPercent}% to {role.targetScore}% goal</em>
-              <button className="icon-text-button" type="button" onClick={() => onSelect(role.roleId)}>
-                <Target aria-hidden="true" />
-                View learning
-              </button>
-              <button className="queue-icon-button" type="button" onClick={() => onRemove(role.id)} aria-label={`Remove ${role.roleTitle}`}>
-                <Trash2 aria-hidden="true" />
-              </button>
-            </article>
-          ))}
-        </div>
+      {candidates.length ? (
+        <ul className="learning-roster-list">
+          {candidates.map((candidate) => {
+            const recommendedRole = candidate.topPositions[0];
+            const assignedCount =
+              candidate.assignedLearningModules?.length ?? 0;
+            return (
+              <li key={candidate.id}>
+                <button
+                  aria-current={
+                    candidate.id === selectedCandidateId ? "true" : undefined
+                  }
+                  className={
+                    candidate.id === selectedCandidateId ? "is-selected" : ""
+                  }
+                  onClick={() => onSelect(candidate.id)}
+                  type="button"
+                >
+                  <FileText aria-hidden="true" />
+                  <span>
+                    <strong>{candidate.candidateName}</strong>
+                    <small>{candidate.fileName}</small>
+                    <em>
+                      {recommendedRole?.role.title ?? "No recommendation"}
+                    </em>
+                  </span>
+                  <b>{assignedCount}</b>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
       ) : (
         <EmptyPanel
-          title="No saved target roles"
-          text="Bookmark a comparison role from the dashboard sidebar to track gap progress on Learning. Uploaded candidates already appear under Analyses—that action only pins the job role for progress, not the résumés."
+          title="No uploaded resumes"
+          text="Upload and analyze resumes from the Dashboard tab. Each resume will appear here with its own recommended training target."
         />
       )}
     </section>
@@ -1528,31 +2146,81 @@ function SavedRoleProgress({
 function LearningAssignmentPanel({
   busy,
   candidate,
+  onRoleChange,
   onToggle,
-  role
+  role,
+  selectedMatch,
 }: {
   busy: boolean;
   candidate?: CandidateAnalysis;
+  onRoleChange: (roleId: string) => void;
   onToggle: (moduleId: string, assigned: boolean) => void;
   role: RoleRequirement;
+  selectedMatch?: CandidateAnalysis["topPositions"][number];
 }) {
   const assignedModules = new Set(candidate?.assignedLearningModules ?? []);
   const candidateMissingSkills = new Set(
-    candidate?.topPositions.find((position) => position.role.id === role.id)?.missingSkills.map((gap) => gap.skill) ??
+    candidate?.topPositions
+      .find((position) => position.role.id === role.id)
+      ?.missingSkills.map((gap) => gap.skill) ??
       candidate?.topPositions[0]?.missingSkills.map((gap) => gap.skill) ??
-      []
+      [],
   );
 
   return (
     <section className="concept-panel">
       <div className="panel-heading">
-        <h2>Learning Module Assignments</h2>
-        <span>{candidate ? role.title : "No resume selected"}</span>
+        <h2>Recommended Training</h2>
+        <span>
+          {candidate
+            ? `${selectedMatch?.score ?? 0}% role fit`
+            : "No resume selected"}
+        </span>
       </div>
       {candidate ? (
         <>
+          <div className="learning-assignment-summary">
+            <div>
+              <strong>{candidate.candidateName}</strong>
+              <span>
+                {candidate.fileName}{" "}
+                <CandidateResumeFileLinks candidate={candidate} />
+              </span>
+            </div>
+            <label className="role-context">
+              Training target
+              <select
+                value={role.id}
+                onChange={(event) => onRoleChange(event.target.value)}
+              >
+                {candidate.topPositions.map((recommendation) => (
+                  <option
+                    key={recommendation.role.id}
+                    value={recommendation.role.id}
+                  >
+                    {recommendation.role.title} ({recommendation.score}%)
+                  </option>
+                ))}
+                {roles
+                  .filter(
+                    (candidateRole) =>
+                      !candidate.topPositions.some(
+                        (recommendation) =>
+                          recommendation.role.id === candidateRole.id,
+                      ),
+                  )
+                  .map((candidateRole) => (
+                    <option key={candidateRole.id} value={candidateRole.id}>
+                      {candidateRole.title}
+                    </option>
+                  ))}
+              </select>
+            </label>
+          </div>
           <p className="m-0 mb-3 text-[12px] leading-snug text-muted">
-            Assign role-specific learning modules directly to {candidate.candidateName}&apos;s saved resume.
+            SkillMatch recommends the training target from this resume&apos;s
+            ranked roles. Recruiters can change the target here when interview
+            evidence or manager context points somewhere better.
           </p>
           <div className="learning-grid">
             {Object.entries(role.learning).map(([skill, course]) => {
@@ -1560,7 +2228,10 @@ function LearningAssignmentPanel({
               const assigned = assignedModules.has(moduleId);
               const recommended = candidateMissingSkills.has(skill);
               return (
-                <article className={`learning-item learning-assignment-item ${assigned ? "is-assigned" : ""}`} key={moduleId}>
+                <article
+                  className={`learning-item learning-assignment-item ${assigned ? "is-assigned" : ""}`}
+                  key={moduleId}
+                >
                   <GraduationCap aria-hidden="true" />
                   <div>
                     <strong>{course}</strong>
@@ -1570,7 +2241,11 @@ function LearningAssignmentPanel({
                     </span>
                   </div>
                   <button
-                    className={assigned ? "icon-text-button assigned-module-button" : "icon-text-button"}
+                    className={
+                      assigned
+                        ? "icon-text-button assigned-module-button"
+                        : "icon-text-button"
+                    }
                     disabled={busy}
                     onClick={() => onToggle(moduleId, !assigned)}
                     type="button"
@@ -1583,79 +2258,34 @@ function LearningAssignmentPanel({
           </div>
         </>
       ) : (
-        <p className="list-placeholder">Upload and analyze a resume, then assign learning modules from this screen.</p>
-      )}
-    </section>
-  );
-}
-
-function AiInsightPanel({ insight }: { insight: CandidateAnalysis["aiInsight"] }) {
-  return (
-    <section className="concept-panel ai-insight-panel">
-      <div className="panel-heading">
-        <h2>
-          <Sparkles aria-hidden="true" className="inline-icon" />
-          AI resume review
-        </h2>
-        <span>Advisory</span>
-      </div>
-      {insight ? (
-        <div className="ai-insight-body">
-          <p className="ai-insight-summary">{insight.summary}</p>
-          <div className="ai-insight-columns">
-            <div>
-              <h3>Strengths</h3>
-              <ul>
-                {insight.strengths.map((item) => (
-                  <li key={item}>{item}</li>
-                ))}
-              </ul>
-            </div>
-            <div>
-              <h3>Development areas</h3>
-              <ul>
-                {insight.developmentAreas.map((item) => (
-                  <li key={item}>{item}</li>
-                ))}
-              </ul>
-            </div>
-          </div>
-          <div>
-            <h3>Role fit</h3>
-            <p>{insight.roleFitNotes}</p>
-          </div>
-          {insight.followUpQuestions.length ? (
-            <div>
-              <h3>Follow-up questions</h3>
-              <ul className="follow-up-list">
-                {insight.followUpQuestions.map((item) => (
-                  <li key={item}>{item}</li>
-                ))}
-              </ul>
-            </div>
-          ) : null}
-        </div>
-      ) : (
         <p className="list-placeholder">
-          When optional AI resume review is enabled for your workspace, a structured narrative appears after each upload.
-          Skill matching above still runs without it.
+          Upload and analyze a resume, then assign learning modules from this
+          screen.
         </p>
       )}
     </section>
   );
 }
 
-function RecommendationPanel({ candidate }: { candidate?: CandidateAnalysis }) {
+function RecommendationPanel({
+  candidate,
+  compact = false,
+}: {
+  candidate?: CandidateAnalysis;
+  compact?: boolean;
+}) {
   const positions = candidate?.topPositions ?? [];
   return (
-    <section className="concept-panel">
+    <section
+      className={compact ? "rail-recommendation-panel" : "concept-panel"}
+    >
       <div className="panel-heading">
         <h2>Recommended Positions</h2>
         <span>Prioritized</span>
       </div>
       {positions.length ? (
         <ol className="recommendation-list">
-          {positions.slice(0, 5).map((recommendation) => (
+          {positions.slice(0, compact ? 3 : 5).map((recommendation) => (
             <li key={recommendation.role.id}>
               <b>{recommendation.rank}</b>
               <div>
@@ -1675,16 +2305,22 @@ function RecommendationPanel({ candidate }: { candidate?: CandidateAnalysis }) {
   );
 }
 
-function RecentCandidates({ candidates, onSelect }: { candidates: CandidateAnalysis[]; onSelect: (id: string) => void }) {
+function RecentCandidates({
+  candidates,
+  onSelect,
+}: {
+  candidates: CandidateAnalysis[];
+  onSelect: (id: string) => void;
+}) {
   return (
     <section className="concept-panel">
       <div className="panel-heading">
-        <h2>Recent Analyses</h2>
+        <h2>Previous Resumes</h2>
         <span>{candidates.length}</span>
       </div>
       {candidates.length ? (
         <ul className="recent-list">
-          {candidates.slice(0, 4).map((candidate) => (
+          {candidates.slice(0, 8).map((candidate) => (
             <li key={candidate.id} className="recent-list-item">
               <button type="button" onClick={() => onSelect(candidate.id)}>
                 <FileText aria-hidden="true" />
@@ -1700,7 +2336,8 @@ function RecentCandidates({ candidates, onSelect }: { candidates: CandidateAnaly
         </ul>
       ) : (
         <p className="list-placeholder">
-          No analyses yet. Upload and process résumés from the Dashboard tab—completed analyses will show up here.
+          No uploaded resumes yet. Completed analyses will stay visible here
+          while you review dashboard details.
         </p>
       )}
     </section>
@@ -1737,7 +2374,11 @@ function HistoryTable({
       <div className="panel-heading">
         <h2>Analysis History</h2>
         <span>
-          {status === "forbidden" ? "—" : status === "loading" ? "…" : analyses.length}
+          {status === "forbidden"
+            ? "—"
+            : status === "loading"
+              ? "…"
+              : analyses.length}
         </span>
       </div>
       {status === "loading" ? (
@@ -1745,10 +2386,13 @@ function HistoryTable({
       ) : null}
       {status === "forbidden" ? (
         <div className="rounded-lg border border-border-strong bg-brand-light px-3 py-3 text-[13px] leading-relaxed text-ink">
-          <strong className="font-semibold">Analysis history is limited by role</strong>
+          <strong className="font-semibold">
+            Analysis history is limited by role
+          </strong>
           <p className="m-0 mt-2 text-muted">
-            Standard employee accounts do not see organization-wide analysis history. Recruiter, hiring manager,
-            learning and development, and system admin roles do. Your SkillMatch overview and candidate cards
+            Standard employee accounts do not see organization-wide analysis
+            history. Recruiter, hiring manager, learning and development, and
+            system admin roles do. Your SkillMatch overview and candidate cards
             above still reflect résumés processed in this session.
           </p>
         </div>
@@ -1778,7 +2422,8 @@ function HistoryTable({
       ) : null}
       {status === "ready" && analyses.length === 0 ? (
         <p className="m-0 text-[13px] text-muted">
-          No history rows yet—history is appended when uploads save successfully after analysis.
+          No history rows yet—history is appended when uploads save successfully
+          after analysis.
         </p>
       ) : null}
     </section>

--- a/app/globals.css
+++ b/app/globals.css
@@ -38,17 +38,12 @@
   /* Elevation — slightly cooler tint for enterprise feel */
   --shadow-xs: 0 1px 2px rgba(15, 23, 42, 0.04);
   --shadow-sm:
-    0 1px 3px rgba(15, 23, 42, 0.06),
-    0 1px 2px rgba(15, 23, 42, 0.04);
-  --shadow:
-    0 4px 16px rgba(15, 23, 42, 0.07),
-    0 2px 4px rgba(15, 23, 42, 0.04);
+    0 1px 3px rgba(15, 23, 42, 0.06), 0 1px 2px rgba(15, 23, 42, 0.04);
+  --shadow: 0 4px 16px rgba(15, 23, 42, 0.07), 0 2px 4px rgba(15, 23, 42, 0.04);
   --shadow-md:
-    0 10px 28px rgba(15, 23, 42, 0.08),
-    0 3px 8px rgba(15, 23, 42, 0.05);
+    0 10px 28px rgba(15, 23, 42, 0.08), 0 3px 8px rgba(15, 23, 42, 0.05);
   --shadow-lg:
-    0 22px 52px rgba(15, 23, 42, 0.1),
-    0 8px 16px rgba(15, 23, 42, 0.06);
+    0 22px 52px rgba(15, 23, 42, 0.1), 0 8px 16px rgba(15, 23, 42, 0.06);
 
   /* Radii */
   --radius-sm: 8px;
@@ -62,7 +57,8 @@
   /* Motion (skill: 150–300ms) */
   --t: 200ms cubic-bezier(0.4, 0, 0.2, 1);
   --focus-ring: 0 0 0 2px var(--panel), 0 0 0 4px rgba(2, 132, 199, 0.35);
-  --focus-ring-amber: 0 0 0 2px var(--panel), 0 0 0 4px rgba(245, 158, 11, 0.45);
+  --focus-ring-amber:
+    0 0 0 2px var(--panel), 0 0 0 4px rgba(245, 158, 11, 0.45);
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -93,9 +89,17 @@ body {
   background: var(--bg);
   color: var(--ink);
   font-family:
-    var(--font-inter, Inter), ui-sans-serif, system-ui, -apple-system,
-    BlinkMacSystemFont, "Segoe UI", sans-serif;
-  font-feature-settings: "kern" 1, "liga" 1, "cv11" 1;
+    var(--font-inter, Inter),
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  font-feature-settings:
+    "kern" 1,
+    "liga" 1,
+    "cv11" 1;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -185,7 +189,9 @@ button:focus-visible,
   padding: 10px 14px;
   font-size: 13px;
   font-weight: 600;
-  transition: background var(--t), color var(--t);
+  transition:
+    background var(--t),
+    color var(--t);
 }
 
 .top-nav-item svg {
@@ -301,7 +307,10 @@ button:focus-visible,
   font-size: 13px;
   font-weight: 600;
   text-align: left;
-  transition: background var(--t), color var(--t), box-shadow var(--t);
+  transition:
+    background var(--t),
+    color var(--t),
+    box-shadow var(--t);
   box-shadow: inset 3px 0 0 transparent;
 }
 
@@ -421,7 +430,9 @@ input {
   color: var(--ink);
   padding: 0 12px;
   font-weight: 500;
-  transition: border-color var(--t), box-shadow var(--t);
+  transition:
+    border-color var(--t),
+    box-shadow var(--t);
 }
 
 select:hover,
@@ -485,7 +496,10 @@ input:focus-visible {
   padding: 0 14px;
   font-size: 12.5px;
   font-weight: 600;
-  transition: background var(--t), border-color var(--t), color var(--t);
+  transition:
+    background var(--t),
+    border-color var(--t),
+    color var(--t);
 }
 
 .icon-text-button:hover {
@@ -509,6 +523,38 @@ input:focus-visible {
     minmax(280px, min(100%, 380px));
   gap: clamp(16px, 1.25vw, 28px);
   align-items: start;
+}
+
+.dashboard-workbench {
+  grid-template-columns: minmax(260px, 300px) minmax(520px, 1fr) minmax(
+      260px,
+      310px
+    );
+  gap: 16px;
+}
+
+.dashboard-left-rail,
+.dashboard-right-rail {
+  position: sticky;
+  top: 16px;
+  max-height: calc(100vh - 32px);
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+}
+
+.dashboard-left-rail {
+  align-self: start;
+}
+
+.dashboard-right-rail {
+  align-self: start;
+  max-height: none;
+  overflow: visible;
+  padding-right: 2px;
+}
+
+.dashboard-main-panel {
+  min-width: 0;
 }
 
 .concept-panel,
@@ -555,6 +601,7 @@ input:focus-visible {
   justify-content: space-between;
   gap: 12px;
   margin-bottom: 14px;
+  padding: 1rem;
 }
 
 .panel-heading span {
@@ -574,6 +621,22 @@ input:focus-visible {
   height: 16px;
   color: var(--brand-dark);
   flex-shrink: 0;
+}
+
+.rail-recommendation-panel {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+  border-top: 1px solid var(--border);
+  padding-top: 14px;
+}
+
+.rail-recommendation-panel .panel-heading {
+  margin-bottom: 0;
+}
+
+.rail-recommendation-panel .recommendation-list li {
+  min-height: 42px;
 }
 
 .ai-insight-body {
@@ -629,7 +692,9 @@ input:focus-visible {
   background: var(--panel-soft);
   color: var(--muted);
   text-align: center;
-  transition: border-color var(--t), background var(--t);
+  transition:
+    border-color var(--t),
+    background var(--t);
 }
 
 .drop-zone:hover {
@@ -709,7 +774,10 @@ input:focus-visible {
   border: 1px solid var(--border);
   background: var(--panel);
   color: var(--muted);
-  transition: background var(--t), border-color var(--t), color var(--t);
+  transition:
+    background var(--t),
+    border-color var(--t),
+    color var(--t);
 }
 
 .queue-clear-button:hover,
@@ -814,7 +882,10 @@ input:focus-visible {
   font-size: 13.5px;
   font-weight: 700;
   letter-spacing: -0.1px;
-  transition: background var(--t), box-shadow var(--t), transform var(--t);
+  transition:
+    background var(--t),
+    box-shadow var(--t),
+    transform var(--t);
 }
 
 .run-button:hover:not(:disabled),
@@ -858,7 +929,7 @@ input:focus-visible {
 /* ─── Skill match overview ───────────────────────────────────── */
 
 .overview-panel {
-  min-height: min(560px, 70vh);
+  min-height: 0;
 }
 
 .overview-content {
@@ -868,11 +939,9 @@ input:focus-visible {
 
 .overview-summary {
   display: grid;
-  grid-template-columns: minmax(168px, 0.38fr) minmax(0, 1fr) minmax(0, 1fr);
-  gap: clamp(16px, 2vw, 32px);
-  align-items: start;
-  padding-bottom: 18px;
-  border-bottom: 1px solid var(--border);
+  grid-template-columns: minmax(126px, 0.72fr) repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  align-items: stretch;
 }
 
 .score-column {
@@ -880,9 +949,20 @@ input:focus-visible {
   place-items: center;
   align-content: start;
   gap: 8px;
-  padding: 4px 14px 0 4px;
-  border-right: 1px solid var(--border);
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--panel-soft);
+  padding: 14px 10px;
   text-align: center;
+}
+
+.overview-summary > div:not(.score-column) {
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--panel-soft);
+  padding: 14px;
 }
 
 .score-column > span {
@@ -1006,6 +1086,164 @@ input:focus-visible {
   font-size: 12.5px;
   line-height: 1.5;
   text-align: center;
+}
+
+.dashboard-stats-panel {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+  border-top: 1px solid var(--border);
+  padding-top: 14px;
+}
+
+.role-distribution-card {
+  display: grid;
+  grid-column: 1 / -1;
+  gap: 8px;
+}
+
+.dashboard-stat-card,
+.role-distribution-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--panel-soft);
+  padding: 13px 14px;
+}
+
+.dashboard-stat-card {
+  display: grid;
+  align-content: center;
+  gap: 5px;
+  min-height: 96px;
+}
+
+.dashboard-stat-card span,
+.role-distribution-card > span {
+  color: var(--muted);
+  font-size: 11.5px;
+  font-weight: 700;
+}
+
+.dashboard-stat-card strong {
+  color: var(--ink);
+  font-size: 28px;
+  font-weight: 800;
+  letter-spacing: -1px;
+}
+
+.role-distribution-card ul {
+  display: grid;
+  gap: 7px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.role-distribution-card li {
+  display: grid;
+  grid-template-columns: minmax(120px, 0.9fr) minmax(80px, 1fr) 22px;
+  gap: 8px;
+  align-items: center;
+}
+
+.role-distribution-card small {
+  overflow: hidden;
+  color: var(--ink);
+  font-size: 11.5px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.role-distribution-card div {
+  height: 7px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--border);
+}
+
+.role-distribution-card i {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--brand);
+}
+
+.role-distribution-card b {
+  color: var(--muted);
+  font-size: 11.5px;
+  text-align: right;
+}
+
+.role-distribution-card p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.dashboard-gap-panel {
+  display: grid;
+  gap: 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: linear-gradient(180deg, #fafafa 0%, var(--panel-soft) 100%);
+  padding: 16px;
+}
+
+.dashboard-gap-panel .panel-heading {
+  margin-bottom: 0;
+  padding: 0;
+}
+
+.dashboard-gap-list {
+  display: grid;
+  gap: 7px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.dashboard-gap-list li {
+  display: grid;
+  grid-template-columns: minmax(112px, 0.8fr) minmax(90px, 1fr) 24px;
+  gap: 8px;
+  align-items: center;
+  min-height: 28px;
+  border-bottom: 1px solid var(--border);
+}
+
+.dashboard-gap-list li:last-child {
+  border-bottom: 0;
+}
+
+.dashboard-gap-skill {
+  overflow: hidden;
+  color: var(--ink);
+  font-size: 11.5px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dashboard-gap-meter {
+  height: 7px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--border);
+}
+
+.dashboard-gap-meter span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: #f97316;
+}
+
+.dashboard-gap-list strong {
+  color: var(--muted);
+  font-size: 11.5px;
+  font-weight: 700;
+  text-align: right;
 }
 
 /* ─── Skill gap chart ────────────────────────────────────────── */
@@ -1331,7 +1569,12 @@ input:focus-visible {
 }
 
 .recent-list .recent-list-item .candidate-resume-links {
+  display: inline-flex;
   padding-left: 27px;
+}
+
+.recent-list .recent-list-item .candidate-resume-links-sep {
+  display: inline;
 }
 
 /* ─── Bottom grid ────────────────────────────────────────────── */
@@ -1473,6 +1716,26 @@ meter::-moz-meter-bar {
   gap: 12px;
 }
 
+.learning-toolbar {
+  align-items: flex-start;
+}
+
+.learning-toolbar h2 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 18px;
+  font-weight: 800;
+  letter-spacing: -0.3px;
+}
+
+.learning-toolbar p {
+  max-width: 720px;
+  margin: 4px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
 .filter-toolbar {
   display: grid;
   grid-template-columns: 1.4fr repeat(3, minmax(140px, 1fr));
@@ -1490,6 +1753,134 @@ meter::-moz-meter-bar {
   text-transform: uppercase;
 }
 
+.chip-filter-label {
+  min-width: 0;
+}
+
+.chip-filter-control {
+  position: relative;
+}
+
+.chip-filter-input-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  min-height: 38px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--panel);
+  padding: 5px 7px;
+  transition:
+    border-color var(--t),
+    box-shadow var(--t);
+}
+
+.chip-filter-control:focus-within .chip-filter-input-row {
+  border-color: var(--brand);
+  box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.14);
+}
+
+.chip-filter-input-row input {
+  flex: 1 1 130px;
+  min-width: 90px;
+  min-height: 26px;
+  border: 0;
+  background: transparent;
+  padding: 0 4px;
+  box-shadow: none !important;
+}
+
+.chip-filter-input-row input:focus-visible {
+  outline: 0;
+  box-shadow: none !important;
+}
+
+.filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 26px;
+  border: 1px solid #bfdbfe;
+  border-radius: var(--radius-full);
+  background: var(--blue-bg);
+  color: var(--blue);
+  padding: 0 7px 0 10px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.filter-chip button {
+  display: grid;
+  place-items: center;
+  width: 18px;
+  height: 18px;
+  border: 0;
+  border-radius: var(--radius-full);
+  background: transparent;
+  color: currentColor;
+  padding: 0;
+}
+
+.filter-chip button:hover {
+  background: rgba(37, 99, 235, 0.12);
+}
+
+.filter-chip svg {
+  width: 12px;
+  height: 12px;
+}
+
+.chip-filter-menu {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  display: grid;
+  max-height: 260px;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  padding: 6px;
+}
+
+.chip-filter-menu button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 36px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--ink);
+  padding: 0 9px;
+  text-align: left;
+}
+
+.chip-filter-menu button:hover {
+  background: var(--panel-soft);
+}
+
+.chip-filter-menu span {
+  font-size: 12.5px;
+  font-weight: 700;
+}
+
+.chip-filter-menu small {
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .search-box {
   display: grid;
   grid-template-columns: 17px minmax(200px, 400px);
@@ -1501,7 +1892,9 @@ meter::-moz-meter-bar {
   background: var(--panel);
   padding: 0 14px;
   color: var(--muted);
-  transition: border-color var(--t), box-shadow var(--t);
+  transition:
+    border-color var(--t),
+    box-shadow var(--t);
 }
 
 .search-box:focus-within {
@@ -1548,7 +1941,9 @@ meter::-moz-meter-bar {
   border-radius: var(--radius);
   background: var(--panel);
   box-shadow: var(--shadow-sm);
-  transition: box-shadow var(--t), transform var(--t);
+  transition:
+    box-shadow var(--t),
+    transform var(--t);
 }
 
 .candidate-card:hover,
@@ -1633,6 +2028,117 @@ meter::-moz-meter-bar {
 
 .learning-grid {
   grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.learning-layout {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  align-items: stretch;
+}
+
+.learning-roster-panel {
+  display: grid;
+  align-content: start;
+  gap: 12px;
+  height: 100%;
+}
+
+.learning-roster-list {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.learning-roster-list button {
+  display: grid;
+  grid-template-columns: 22px minmax(0, 1fr) 24px;
+  gap: 9px;
+  align-items: center;
+  width: 100%;
+  min-height: 64px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--panel);
+  color: var(--ink);
+  padding: 9px 10px;
+  text-align: left;
+  transition:
+    background var(--t),
+    border-color var(--t),
+    box-shadow var(--t);
+}
+
+.learning-roster-list button:hover,
+.learning-roster-list button.is-selected {
+  border-color: var(--brand);
+  background: var(--brand-light);
+  box-shadow: var(--shadow-sm);
+}
+
+.learning-roster-list svg {
+  width: 20px;
+  height: 20px;
+  color: var(--blue);
+}
+
+.learning-roster-list span {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.learning-roster-list strong,
+.learning-assignment-summary strong {
+  overflow: hidden;
+  color: var(--ink);
+  font-size: 12.5px;
+  font-weight: 700;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.learning-roster-list small,
+.learning-roster-list em,
+.learning-assignment-summary span {
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 11.25px;
+  font-style: normal;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.learning-roster-list b {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 999px;
+  background: var(--blue-bg);
+  color: var(--blue);
+  font-size: 11.5px;
+  font-weight: 800;
+}
+
+.learning-assignment-summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 0.55fr);
+  gap: 14px;
+  align-items: end;
+  margin-bottom: 12px;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 14px;
+}
+
+.learning-assignment-summary > div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
 }
 
 .learning-item {
@@ -1723,31 +2229,91 @@ meter::-moz-meter-bar {
 
 .settings-grid {
   display: grid;
-  grid-template-columns: 0.8fr 1.2fr;
-  gap: 32px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
 }
 
-.settings-grid h2 {
-  margin: 0 0 8px;
-  font-size: 15px;
+.settings-section {
+  display: grid;
+  align-content: start;
+  gap: 14px;
+}
+
+.settings-wide-section {
+  grid-column: 1 / -1;
+  border-top: 1px solid var(--border);
+  padding-top: 18px;
+}
+
+.settings-section label {
+  display: grid;
+  gap: 5px;
+  color: var(--muted);
+  font-size: 11px;
   font-weight: 700;
-  letter-spacing: -0.2px;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
 }
 
-.settings-grid p {
-  margin: 6px 0 0;
-  font-size: 13px;
-  line-height: 1.55;
-}
-
-.settings-grid strong {
-  font-size: 15px;
-  font-weight: 700;
-}
-
-.settings-grid span {
-  font-size: 12.5px;
+.settings-section .panel-heading span {
   text-transform: capitalize;
+}
+
+.settings-toggle {
+  grid-template-columns: 18px minmax(0, 1fr);
+  align-items: start;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--panel-soft);
+  padding: 13px 14px;
+  text-transform: none !important;
+}
+
+.settings-toggle input {
+  width: 16px;
+  min-height: 16px;
+  margin-top: 2px;
+  accent-color: var(--brand);
+}
+
+.settings-toggle span {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.settings-toggle strong {
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.settings-toggle small,
+.settings-actions p {
+  color: var(--muted);
+  font-size: 12.5px;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.45;
+  text-transform: none;
+}
+
+.settings-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.settings-actions p {
+  margin: 0;
+}
+
+.settings-actions .primary-action {
+  width: auto;
+  min-width: 150px;
+  justify-content: center;
+  white-space: nowrap;
 }
 
 .empty-panel {
@@ -1838,6 +2404,8 @@ meter::-moz-meter-bar {
   .concept-grid,
   .bottom-grid,
   .data-grid,
+  .dashboard-stats-panel,
+  .learning-layout,
   .learning-grid,
   .metric-grid,
   .role-matrix,
@@ -1847,6 +2415,25 @@ meter::-moz-meter-bar {
 
   .overview-panel {
     min-height: auto;
+  }
+
+  .dashboard-left-rail,
+  .dashboard-right-rail {
+    position: static;
+    max-height: none;
+    overflow: visible;
+  }
+
+  .dashboard-left-rail {
+    order: 1;
+  }
+
+  .dashboard-right-rail {
+    order: 2;
+  }
+
+  .dashboard-main-panel {
+    order: 3;
   }
 
   .side-nav {
@@ -1907,8 +2494,10 @@ meter::-moz-meter-bar {
   .brand-block,
   .overview-content,
   .overview-summary,
+  .dashboard-stats-panel,
   .audit-log-row,
   .filter-toolbar,
+  .learning-assignment-summary,
   .saved-progress-grid article,
   .system-health,
   .screen-toolbar,
@@ -1943,5 +2532,13 @@ meter::-moz-meter-bar {
 
   .data-grid {
     grid-template-columns: 1fr;
+  }
+
+  .settings-actions {
+    display: grid;
+  }
+
+  .settings-actions .primary-action {
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- Reworked the dashboard into a denser workbench layout with sticky rails and a more balanced center panel
- Moved résumé recommendations into the left rail and simplified the right rail to keep previous resumes always accessible
- Restyled the workforce gaps panel and related dashboard cards so they match the rest of the UI more closely
- Tightened spacing and responsive behavior to reduce empty whitespace on desktop and keep mobile stacking usable

## Testing
- `npm run lint`
- Browser-verified the dashboard layout in the local app, including panel alignment, sticky behavior, and mobile stacking