### PR TITLE
Add login throttling and account lockout protections

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,10 @@ AUTH_SECRET="replace-with-a-long-random-secret"
 BETTER_AUTH_SECRET=""
 # Required in production to disable demo credential fallback.
 AUTH_USERS_JSON='[{"name":"Demo Recruiter","email":"recruiter@skillmatch.demo","role":"recruiter","password":"SkillMatchDemo!23"},{"name":"Demo Admin","email":"admin@skillmatch.demo","role":"system_admin","password":"SkillMatchAdmin!23"},{"name":"Demo Learning","email":"learning@skillmatch.demo","role":"learning_development","password":"SkillMatchLearn!23"}]'
+# Optional login throttling controls. Defaults: 5 attempts within 15 minutes, then a 15-minute lockout.
+AUTH_LOGIN_MAX_ATTEMPTS="5"
+AUTH_LOGIN_WINDOW_MINUTES="15"
+AUTH_LOGIN_LOCKOUT_MINUTES="15"
 
 # Database storage is optional in local development and required in production.
 # Cloudflare R2 / S3-compatible resume object storage is also optional locally.

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { setSessionUser } from "@/lib/auth";
-import { verifyCredentials } from "@/lib/auth-model";
+import { getLoginThrottleStatus, recordFailedLoginAttempt, resetLoginThrottle, verifyCredentials } from "@/lib/auth-model";
 import { appendAuditEvent } from "@/lib/db";
 import { loginRequestSchema, parseJsonRequestBody } from "@/lib/validation";
 
@@ -14,6 +14,34 @@ async function appendLoginAuditEvent(input: {
   } catch (error) {
     console.error("Unable to append login audit event", error);
   }
+}
+
+function getRequestIpAddress(request: Request) {
+  const forwardedFor = request.headers.get("x-forwarded-for");
+  if (forwardedFor) {
+    const [firstIp] = forwardedFor.split(",");
+    if (firstIp?.trim()) {
+      return firstIp.trim();
+    }
+  }
+
+  const realIp = request.headers.get("x-real-ip");
+  return realIp?.trim() ? realIp.trim() : null;
+}
+
+function createThrottledResponse(retryAfterSeconds: number) {
+  return NextResponse.json(
+    {
+      error: "Too many login attempts. Try again later.",
+      retryAfterSeconds
+    },
+    {
+      status: 429,
+      headers: {
+        "Retry-After": String(retryAfterSeconds)
+      }
+    }
+  );
 }
 
 export async function POST(request: Request) {
@@ -32,22 +60,54 @@ export async function POST(request: Request) {
     }
 
     const { email, password } = data;
-    const user = await verifyCredentials(email, password);
+    const ip = getRequestIpAddress(request);
+    const throttleStatus = getLoginThrottleStatus({ email, ip });
 
-    if (!user) {
+    if (throttleStatus.throttled) {
       await appendLoginAuditEvent({
         actor: email || "anonymous",
         action: "failed_login",
-        details: { reason: "invalid_credentials" }
+        details: {
+          reason: "login_throttled",
+          throttleScope: throttleStatus.scope,
+          retryAfterSeconds: throttleStatus.retryAfterSeconds,
+          ip
+        }
       });
+      return createThrottledResponse(throttleStatus.retryAfterSeconds);
+    }
+
+    const user = await verifyCredentials(email, password);
+
+    if (!user) {
+      const updatedThrottleStatus = recordFailedLoginAttempt({ email, ip });
+
+      await appendLoginAuditEvent({
+        actor: email || "anonymous",
+        action: "failed_login",
+        details: updatedThrottleStatus.throttled
+          ? {
+              reason: "login_throttled",
+              throttleScope: updatedThrottleStatus.scope,
+              retryAfterSeconds: updatedThrottleStatus.retryAfterSeconds,
+              ip
+            }
+          : { reason: "invalid_credentials", ip }
+      });
+
+      if (updatedThrottleStatus.throttled) {
+        return createThrottledResponse(updatedThrottleStatus.retryAfterSeconds);
+      }
+
       return NextResponse.json({ error: "Invalid email or password." }, { status: 401 });
     }
 
+    resetLoginThrottle({ email, ip });
     await setSessionUser(user);
     await appendLoginAuditEvent({
       actor: user.email,
       action: "login",
-      details: { role: user.role }
+      details: { role: user.role, ip }
     });
 
     return NextResponse.json({ user });

--- a/lib/auth-model.ts
+++ b/lib/auth-model.ts
@@ -16,6 +16,24 @@ export type CredentialUser = SessionUser & {
   passwordHash?: string;
 };
 
+type LoginThrottleEntry = {
+  attempts: number;
+  windowStartedAt: number;
+  lockedUntil: number | null;
+};
+
+export type LoginThrottleResult = {
+  throttled: boolean;
+  scope: "email" | "ip" | null;
+  retryAfterSeconds: number;
+};
+
+type LoginThrottleConfig = {
+  maxAttempts: number;
+  windowMs: number;
+  lockoutMs: number;
+};
+
 const fallbackCredentialUsers: CredentialUser[] = [
   {
     name: "Priya Recruiter",
@@ -36,6 +54,127 @@ const fallbackCredentialUsers: CredentialUser[] = [
     password: "SkillMatchLearn!23"
   }
 ];
+
+const defaultLoginThrottleConfig: LoginThrottleConfig = {
+  maxAttempts: 5,
+  windowMs: 15 * 60 * 1000,
+  lockoutMs: 15 * 60 * 1000
+};
+
+const emailLoginThrottle = new Map<string, LoginThrottleEntry>();
+const ipLoginThrottle = new Map<string, LoginThrottleEntry>();
+
+function readPositiveIntegerEnv(name: string, fallback: number) {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function getLoginThrottleConfig(): LoginThrottleConfig {
+  return {
+    maxAttempts: readPositiveIntegerEnv("AUTH_LOGIN_MAX_ATTEMPTS", defaultLoginThrottleConfig.maxAttempts),
+    windowMs: readPositiveIntegerEnv("AUTH_LOGIN_WINDOW_MINUTES", defaultLoginThrottleConfig.windowMs / 60000) * 60000,
+    lockoutMs:
+      readPositiveIntegerEnv("AUTH_LOGIN_LOCKOUT_MINUTES", defaultLoginThrottleConfig.lockoutMs / 60000) * 60000
+  };
+}
+
+function normalizeThrottleEmail(email: string | null | undefined) {
+  const normalized = email?.trim().toLowerCase();
+  return normalized ? normalized : null;
+}
+
+function normalizeThrottleIp(ip: string | null | undefined) {
+  const normalized = ip?.trim();
+  return normalized ? normalized : null;
+}
+
+function resetThrottleEntry(map: Map<string, LoginThrottleEntry>, key: string) {
+  map.delete(key);
+}
+
+function getThrottleEntry(
+  map: Map<string, LoginThrottleEntry>,
+  key: string,
+  config: LoginThrottleConfig,
+  now: number
+) {
+  const entry = map.get(key);
+  if (!entry) {
+    return null;
+  }
+
+  if (entry.lockedUntil && entry.lockedUntil <= now) {
+    resetThrottleEntry(map, key);
+    return null;
+  }
+
+  if (!entry.lockedUntil && now - entry.windowStartedAt >= config.windowMs) {
+    resetThrottleEntry(map, key);
+    return null;
+  }
+
+  return entry;
+}
+
+function getThrottleStatusForScope(
+  map: Map<string, LoginThrottleEntry>,
+  key: string | null,
+  scope: "email" | "ip",
+  config: LoginThrottleConfig,
+  now: number
+): LoginThrottleResult | null {
+  if (!key) {
+    return null;
+  }
+
+  const entry = getThrottleEntry(map, key, config, now);
+  if (!entry?.lockedUntil || entry.lockedUntil <= now) {
+    return null;
+  }
+
+  return {
+    throttled: true,
+    scope,
+    retryAfterSeconds: Math.max(1, Math.ceil((entry.lockedUntil - now) / 1000))
+  };
+}
+
+function recordFailureForScope(
+  map: Map<string, LoginThrottleEntry>,
+  key: string | null,
+  config: LoginThrottleConfig,
+  now: number
+) {
+  if (!key) {
+    return;
+  }
+
+  const current = getThrottleEntry(map, key, config, now);
+  if (!current) {
+    map.set(key, {
+      attempts: 1,
+      windowStartedAt: now,
+      lockedUntil: config.maxAttempts <= 1 ? now + config.lockoutMs : null
+    });
+    return;
+  }
+
+  if (current.lockedUntil && current.lockedUntil > now) {
+    return;
+  }
+
+  const attempts = current.attempts + 1;
+  map.set(key, {
+    attempts,
+    windowStartedAt: current.windowStartedAt,
+    lockedUntil: attempts >= config.maxAttempts ? now + config.lockoutMs : null
+  });
+}
 
 export function createPasswordHash(password: string, salt = crypto.randomBytes(16).toString("base64url")) {
   const key = crypto.scryptSync(password, salt, 64).toString("base64url");
@@ -65,6 +204,53 @@ export function getCredentialUsers() {
   } catch {
     return [];
   }
+}
+
+export function getLoginThrottleStatus(input: { email?: string | null; ip?: string | null }, now = Date.now()) {
+  const config = getLoginThrottleConfig();
+  const emailStatus = getThrottleStatusForScope(
+    emailLoginThrottle,
+    normalizeThrottleEmail(input.email),
+    "email",
+    config,
+    now
+  );
+
+  if (emailStatus) {
+    return emailStatus;
+  }
+
+  return (
+    getThrottleStatusForScope(ipLoginThrottle, normalizeThrottleIp(input.ip), "ip", config, now) ?? {
+      throttled: false,
+      scope: null,
+      retryAfterSeconds: 0
+    }
+  );
+}
+
+export function recordFailedLoginAttempt(input: { email?: string | null; ip?: string | null }, now = Date.now()) {
+  const config = getLoginThrottleConfig();
+  recordFailureForScope(emailLoginThrottle, normalizeThrottleEmail(input.email), config, now);
+  recordFailureForScope(ipLoginThrottle, normalizeThrottleIp(input.ip), config, now);
+  return getLoginThrottleStatus(input, now);
+}
+
+export function resetLoginThrottle(input: { email?: string | null; ip?: string | null }) {
+  const normalizedEmail = normalizeThrottleEmail(input.email);
+  if (normalizedEmail) {
+    resetThrottleEntry(emailLoginThrottle, normalizedEmail);
+  }
+
+  const normalizedIp = normalizeThrottleIp(input.ip);
+  if (normalizedIp) {
+    resetThrottleEntry(ipLoginThrottle, normalizedIp);
+  }
+}
+
+export function resetLoginThrottleState() {
+  emailLoginThrottle.clear();
+  ipLoginThrottle.clear();
 }
 
 export async function verifyCredentials(email: string, password: string): Promise<SessionUser | null> {

--- a/tests/api-json-bodies.test.ts
+++ b/tests/api-json-bodies.test.ts
@@ -5,6 +5,9 @@ const {
   mockGetSessionUser,
   mockCanAccess,
   mockVerifyCredentials,
+  mockGetLoginThrottleStatus,
+  mockRecordFailedLoginAttempt,
+  mockResetLoginThrottle,
   mockAppendAuditEvent,
   mockSaveAnalysis,
   mockAnalyzeResume
@@ -13,6 +16,9 @@ const {
   mockGetSessionUser: vi.fn(),
   mockCanAccess: vi.fn(),
   mockVerifyCredentials: vi.fn(),
+  mockGetLoginThrottleStatus: vi.fn(),
+  mockRecordFailedLoginAttempt: vi.fn(),
+  mockResetLoginThrottle: vi.fn(),
   mockAppendAuditEvent: vi.fn(),
   mockSaveAnalysis: vi.fn(),
   mockAnalyzeResume: vi.fn()
@@ -25,7 +31,10 @@ vi.mock("@/lib/auth", () => ({
 }));
 
 vi.mock("@/lib/auth-model", () => ({
-  verifyCredentials: mockVerifyCredentials
+  verifyCredentials: mockVerifyCredentials,
+  getLoginThrottleStatus: mockGetLoginThrottleStatus,
+  recordFailedLoginAttempt: mockRecordFailedLoginAttempt,
+  resetLoginThrottle: mockResetLoginThrottle
 }));
 
 vi.mock("@/lib/db", () => ({
@@ -45,6 +54,16 @@ describe("API JSON body handling", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCanAccess.mockReturnValue(true);
+    mockGetLoginThrottleStatus.mockReturnValue({
+      throttled: false,
+      scope: null,
+      retryAfterSeconds: 0
+    });
+    mockRecordFailedLoginAttempt.mockReturnValue({
+      throttled: false,
+      scope: null,
+      retryAfterSeconds: 0
+    });
     mockGetSessionUser.mockResolvedValue({
       name: "Priya Recruiter",
       email: "recruiter@skillmatch.demo",
@@ -70,6 +89,104 @@ describe("API JSON body handling", () => {
     });
     expect(mockSetSessionUser).not.toHaveBeenCalled();
     expect(mockVerifyCredentials).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 and audits when the login request is already throttled", async () => {
+    mockGetLoginThrottleStatus.mockReturnValue({
+      throttled: true,
+      scope: "ip",
+      retryAfterSeconds: 90
+    });
+
+    const response = await loginPost(
+      new Request("http://localhost/api/auth/login", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-forwarded-for": "203.0.113.9"
+        },
+        body: JSON.stringify({ email: "blocked@example.com", password: "bad-password" })
+      })
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBe("90");
+    await expect(response.json()).resolves.toEqual({
+      error: "Too many login attempts. Try again later.",
+      retryAfterSeconds: 90
+    });
+    expect(mockVerifyCredentials).not.toHaveBeenCalled();
+    expect(mockAppendAuditEvent).toHaveBeenCalledWith({
+      actor: "blocked@example.com",
+      action: "failed_login",
+      details: {
+        reason: "login_throttled",
+        throttleScope: "ip",
+        retryAfterSeconds: 90,
+        ip: "203.0.113.9"
+      }
+    });
+  });
+
+  it("returns 429 when a failed credential attempt trips the throttle", async () => {
+    mockVerifyCredentials.mockResolvedValue(null);
+    mockRecordFailedLoginAttempt.mockReturnValue({
+      throttled: true,
+      scope: "email",
+      retryAfterSeconds: 120
+    });
+
+    const response = await loginPost(
+      new Request("http://localhost/api/auth/login", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-real-ip": "198.51.100.11"
+        },
+        body: JSON.stringify({ email: "user@example.com", password: "wrong-password" })
+      })
+    );
+
+    expect(response.status).toBe(429);
+    expect(mockRecordFailedLoginAttempt).toHaveBeenCalledWith({
+      email: "user@example.com",
+      ip: "198.51.100.11"
+    });
+    expect(mockAppendAuditEvent).toHaveBeenCalledWith({
+      actor: "user@example.com",
+      action: "failed_login",
+      details: {
+        reason: "login_throttled",
+        throttleScope: "email",
+        retryAfterSeconds: 120,
+        ip: "198.51.100.11"
+      }
+    });
+  });
+
+  it("clears throttle state after a successful login", async () => {
+    mockVerifyCredentials.mockResolvedValue({
+      name: "Demo Admin",
+      email: "admin@example.com",
+      role: "system_admin"
+    });
+
+    const response = await loginPost(
+      new Request("http://localhost/api/auth/login", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-forwarded-for": "198.51.100.12, 10.0.0.10"
+        },
+        body: JSON.stringify({ email: "admin@example.com", password: "correct-password" })
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockResetLoginThrottle).toHaveBeenCalledWith({
+      email: "admin@example.com",
+      ip: "198.51.100.12"
+    });
   });
 
   it("returns a structured 400 for malformed analyze JSON", async () => {
@@ -104,4 +221,5 @@ describe("API JSON body handling", () => {
       details: { reason: "malformed_json" }
     });
   });
+
 });

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { canAccess, createSessionToken, parseSessionToken } from "@/lib/auth";
-import { createPasswordHash, verifyCredentials, type SessionUser } from "@/lib/auth-model";
+import {
+  createPasswordHash,
+  getLoginThrottleStatus,
+  recordFailedLoginAttempt,
+  resetLoginThrottle,
+  resetLoginThrottleState,
+  verifyCredentials,
+  type SessionUser
+} from "@/lib/auth-model";
 
 const admin: SessionUser = {
   name: "Admin",
@@ -24,7 +32,11 @@ function setNodeEnv(value: typeof process.env.NODE_ENV) {
 beforeEach(() => {
   delete process.env.AUTH_SECRET;
   delete process.env.BETTER_AUTH_SECRET;
+  delete process.env.AUTH_LOGIN_MAX_ATTEMPTS;
+  delete process.env.AUTH_LOGIN_WINDOW_MINUTES;
+  delete process.env.AUTH_LOGIN_LOCKOUT_MINUTES;
   setNodeEnv("test");
+  resetLoginThrottleState();
   vi.useRealTimers();
 });
 
@@ -43,6 +55,10 @@ afterEach(() => {
 
   setNodeEnv(originalNodeEnv);
   delete process.env.AUTH_USERS_JSON;
+  delete process.env.AUTH_LOGIN_MAX_ATTEMPTS;
+  delete process.env.AUTH_LOGIN_WINDOW_MINUTES;
+  delete process.env.AUTH_LOGIN_LOCKOUT_MINUTES;
+  resetLoginThrottleState();
   vi.useRealTimers();
 });
 
@@ -138,5 +154,69 @@ describe("auth and RBAC", () => {
     });
     await expect(verifyCredentials("admin@example.com", "wrong-password")).resolves.toBeNull();
     delete process.env.AUTH_USERS_JSON;
+  });
+
+  it("throttles login attempts by normalized email and reports retry timing", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    process.env.AUTH_LOGIN_MAX_ATTEMPTS = "3";
+    process.env.AUTH_LOGIN_LOCKOUT_MINUTES = "10";
+
+    expect(recordFailedLoginAttempt({ email: " Admin@Example.com " })).toEqual({
+      throttled: false,
+      scope: null,
+      retryAfterSeconds: 0
+    });
+    expect(recordFailedLoginAttempt({ email: "admin@example.com" })).toEqual({
+      throttled: false,
+      scope: null,
+      retryAfterSeconds: 0
+    });
+
+    const thirdAttempt = recordFailedLoginAttempt({ email: "admin@example.com" });
+    expect(thirdAttempt.throttled).toBe(true);
+    expect(thirdAttempt.scope).toBe("email");
+    expect(thirdAttempt.retryAfterSeconds).toBe(600);
+
+    expect(getLoginThrottleStatus({ email: "ADMIN@example.com" })).toEqual(thirdAttempt);
+  });
+
+  it("throttles by IP independently from email and expires the lockout window", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    process.env.AUTH_LOGIN_MAX_ATTEMPTS = "2";
+    process.env.AUTH_LOGIN_LOCKOUT_MINUTES = "1";
+
+    recordFailedLoginAttempt({ email: "first@example.com", ip: "203.0.113.10" });
+    const throttled = recordFailedLoginAttempt({ email: "second@example.com", ip: "203.0.113.10" });
+
+    expect(throttled.throttled).toBe(true);
+    expect(throttled.scope).toBe("ip");
+    expect(getLoginThrottleStatus({ email: "other@example.com", ip: "203.0.113.10" }).throttled).toBe(true);
+
+    vi.advanceTimersByTime(60_000);
+
+    expect(getLoginThrottleStatus({ email: "other@example.com", ip: "203.0.113.10" })).toEqual({
+      throttled: false,
+      scope: null,
+      retryAfterSeconds: 0
+    });
+  });
+
+  it("clears throttle state after a successful login path resets the subject", () => {
+    process.env.AUTH_LOGIN_MAX_ATTEMPTS = "2";
+
+    recordFailedLoginAttempt({ email: "user@example.com", ip: "198.51.100.20" });
+    recordFailedLoginAttempt({ email: "user@example.com", ip: "198.51.100.20" });
+
+    expect(getLoginThrottleStatus({ email: "user@example.com", ip: "198.51.100.20" }).throttled).toBe(true);
+
+    resetLoginThrottle({ email: "user@example.com", ip: "198.51.100.20" });
+
+    expect(getLoginThrottleStatus({ email: "user@example.com", ip: "198.51.100.20" })).toEqual({
+      throttled: false,
+      scope: null,
+      retryAfterSeconds: 0
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add configurable per-email and per-IP login throttling with 429 and Retry-After handling
- audit throttled login denials and reset throttle state after successful sign-in
- add route and auth-model coverage for the new throttle behavior

## Testing
- Local validation in this environment was blocked by missing writable npm cache and missing installed dependencies in the shared worktree.
- GitHub Actions on this PR should be treated as the source of truth for final validation.

Closes #8