### PR TITLE
Tighten CI validation workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,13 @@ concurrency:
 
 jobs:
   checks:
-    name: Lint, test, and build
+    name: Lint, tests, build, and smoke
     runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      CI: true
+      NEXT_FONT_GOOGLE_MOCKED_RESPONSES: ${{ github.workspace }}/.github/workflows/next-font-mocks.cjs
+      NEXT_TELEMETRY_DISABLED: 1
 
     steps:
       - name: Checkout
@@ -25,11 +30,17 @@ jobs:
           node-version: 22
           cache: npm
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+
       - name: Install dependencies
         run: npm ci
 
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium webkit chrome msedge
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
 
       - name: Lint
         run: npm run lint
@@ -40,5 +51,15 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Run end-to-end tests
-        run: npm run test:e2e
+      - name: Run Playwright smoke test
+        run: npm run test:e2e:smoke
+
+      - name: Upload Playwright artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-artifacts
+          path: |
+            playwright-report
+            test-results
+          if-no-files-found: ignore

--- a/.github/workflows/next-font-mocks.cjs
+++ b/.github/workflows/next-font-mocks.cjs
@@ -1,0 +1,16 @@
+const mockedCss = `
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 100 900;
+  font-display: swap;
+  src: url("mocked-inter-font.woff2") format("woff2");
+}
+`;
+
+module.exports = new Proxy(
+  {},
+  {
+    get: () => mockedCss
+  }
+);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "dev:ci": "next dev --webpack",
+    "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint .",
     "test": "vitest run",
@@ -12,7 +13,8 @@
     "db:generate": "drizzle-kit generate",
     "db:setup": "node scripts/migrate.mjs",
     "db:migrate": "node scripts/migrate.mjs",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:e2e:smoke": "playwright test tests/e2e/skillmatch.spec.ts --grep \"allows signed-out users to open signup|requires credential sign-in, uploads a PDF resume, and ranks positions\""
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1040.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { defineConfig, devices, type PlaywrightTestConfig } from "@playwright/test";
 
 /** Deterministic credential users used when Playwright starts `next dev` (avoid host .env Neon users). */
@@ -25,6 +26,9 @@ const PLAYWRIGHT_DEMO_USERS = JSON.stringify([
 const edgeChannel =
   process.env.PLAYWRIGHT_EDGE_CHANNEL ??
   (process.platform === "win32" ? "msedge" : undefined);
+const isCI = process.env.CI === "true" || process.env.CI === "1";
+const npmExecutable = process.platform === "win32" ? "npm.cmd" : "npm";
+const mockedFontResponsesPath = path.join(process.cwd(), ".github", "workflows", "next-font-mocks.cjs");
 
 type PlaywrightProject = NonNullable<PlaywrightTestConfig["projects"]>[number];
 
@@ -73,22 +77,28 @@ function getProjects(): PlaywrightProject[] {
 
 export default defineConfig({
   testDir: "./tests/e2e",
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
   timeout: 30_000,
   workers: 1,
+  reporter: isCI
+    ? [["github"], ["html", { open: "never" }]]
+    : [["list"]],
   use: {
     baseURL: "http://127.0.0.1:3000",
     trace: "on-first-retry"
   },
   webServer: {
-    command: "npm run dev -- --hostname 127.0.0.1 --port 3000",
+    command: `${npmExecutable} run dev:ci -- --hostname 127.0.0.1 --port 3000`,
     env: {
       DATABASE_URL: "",
       AUTH_USERS_JSON: PLAYWRIGHT_DEMO_USERS,
       E2E_DISABLE_DATABASE: "1",
+      NEXT_FONT_GOOGLE_MOCKED_RESPONSES: mockedFontResponsesPath,
       NEXT_PUBLIC_SKILLMATCH_E2E_FILE_HOOK: "1"
     },
     url: "http://127.0.0.1:3000/login",
-    reuseExistingServer: process.env.PW_REUSE_SERVER === "1",
+    reuseExistingServer: !isCI && process.env.PW_REUSE_SERVER === "1",
     timeout: 30_000
   },
   projects: getProjects()


### PR DESCRIPTION
## Summary
- cache Playwright browsers and narrow PR validation to a deterministic smoke flow
- force webpack-backed build/dev commands in CI to avoid environment-specific build variance
- mock Google font responses during CI build and smoke startup to keep checks deterministic

## Testing
- Local validation in this environment was blocked by missing installed dependencies and writable git/npm state.
- GitHub Actions on this PR should be treated as the source of truth for final validation.

Closes #28